### PR TITLE
Fix upstream warnings

### DIFF
--- a/src/rsn_supp/wpa.c
+++ b/src/rsn_supp/wpa.c
@@ -2365,7 +2365,7 @@ static void wpa_eapol_key_dump(struct wpa_sm *sm,
 
 	wpa_dbg(sm->ctx->msg_ctx, MSG_DEBUG, "  EAPOL-Key type=%d", key->type);
 	wpa_dbg(sm->ctx->msg_ctx, MSG_DEBUG,
-		"  key_info 0x%x (ver=%d keyidx=%d rsvd=%d %s%s%s%s%s%s%s%s)",
+		"  key_info 0x%x (ver=%d keyidx=%ld rsvd=%ld %s%s%s%s%s%s%s%s)",
 		key_info, key_info & WPA_KEY_INFO_TYPE_MASK,
 		(key_info & WPA_KEY_INFO_KEY_INDEX_MASK) >>
 		WPA_KEY_INFO_KEY_INDEX_SHIFT,


### PR DESCRIPTION
nRF CI treats warnings as errors, so, this is must.