### PR TITLE
Fix a build warning

### DIFF
--- a/src/l2_packet/l2_packet_zephyr.c
+++ b/src/l2_packet/l2_packet_zephyr.c
@@ -82,7 +82,7 @@ static void l2_packet_receive(int sock, void *eloop_ctx, void *sock_ctx)
 	int res;
 	struct sockaddr_ll ll;
 	socklen_t fromlen;
-	struct ieee802_1x_hdr *hdr;
+	const struct ieee802_1x_hdr *hdr;
 
 	os_memset(&ll, 0, sizeof(ll));
 	fromlen = sizeof(ll);


### PR DESCRIPTION
Add const qualifier to the declaration.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>