### PR TITLE
drivers: zephyr: use struct device instead of name

### DIFF
--- a/src/drivers/driver_zephyr.h
+++ b/src/drivers/driver_zephyr.h
@@ -69,7 +69,7 @@ struct zep_wpa_supp_dev_callbk_fns {
 
 struct zep_wpa_supp_dev_ops {
 	void *(*init)(void *supp_drv_if_ctx,
-		      const char *iface_name,
+		      const struct device *dev,
 		      struct zep_wpa_supp_dev_callbk_fns *callbk_fns);
 	void (*deinit)(void *if_priv);
 	int (*scan2)(void *if_priv,


### PR DESCRIPTION
Use device references instead of interface name, so that we can avoid
usage of device_get_binding.