### PR TITLE
Compile out logs based on configured log level

### DIFF
--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -532,7 +532,7 @@ static inline int is_multicast_ether_addr(const u8 *a)
 
 #define broadcast_ether_addr (const u8 *) "\xff\xff\xff\xff\xff\xff"
 
-#include "wpa_debug.h"
+#include <utils/wpa_debug.h>
 
 
 struct wpa_freq_range_list {

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -20,7 +20,7 @@ zephyr_compile_definitions(
 )
 
 zephyr_include_directories(
-	${CMAKE_CURRENT_SOURCE_DIR}/
+	${CMAKE_CURRENT_SOURCE_DIR}/src
 	${HOSTAP_BASE}/
 	${WPA_SUPPLICANT_BASE}/
 	${COMMON_SRC_BASE}/
@@ -40,6 +40,7 @@ zephyr_library_compile_definitions(
 	)
 
 zephyr_library_include_directories(
+	${CMAKE_CURRENT_SOURCE_DIR}/src
 	${HOSTAP_BASE}/
 	${COMMON_SRC_BASE}/utils
 	${COMMON_SRC_BASE}/drivers
@@ -61,7 +62,6 @@ zephyr_library_sources(
 	${COMMON_SRC_BASE}/drivers/driver_zephyr.c
 	${COMMON_SRC_BASE}/utils/base64.c
 	${COMMON_SRC_BASE}/utils/common.c
-	${COMMON_SRC_BASE}/utils/wpa_debug.c
 	${COMMON_SRC_BASE}/utils/wpabuf.c
 	${COMMON_SRC_BASE}/utils/bitfield.c
 	${COMMON_SRC_BASE}/utils/eloop.c
@@ -88,6 +88,7 @@ zephyr_library_sources(
 	${WPA_SUPPLICANT_BASE}/wpa_cli.c	
 	# Zephyr main
 	src/supp_main.c
+	src/utils/wpa_debug.c
 )
 zephyr_library_sources_ifdef(CONFIG_WPA_SUPP_AP
 	${WPA_SUPPLICANT_BASE}/ap.c

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -48,6 +48,20 @@ config WPA_SUPP_P2P
     select WPA_SUPP_AP
     select WPA_SUPP_WPS
 
+module = WPA_SUPP
+module-str = WPA supplicant
+source "subsys/logging/Kconfig.template.log_config"
+
 config WPA_SUPP_DEBUG_LEVEL
-	string "Debug level for prints"
-	default "INFO"
+    int "Min compiled-in debug message level for WPA supplicant"
+    default 0 if WPA_SUPP_LOG_LEVEL_DBG # MSG_EXCESSIVE
+    default 3 if WPA_SUPP_LOG_LEVEL_INF # MSG_INFO
+    default 4 if WPA_SUPP_LOG_LEVEL_WRN # MSG_WARNING
+    default 5 if WPA_SUPP_LOG_LEVEL_ERR # MSG_ERROR
+    default 6
+    help
+      Minimum priority level of a debug message emitted by WPA supplicant that
+      is compiled-in the firmware. See wpa_debug.h file of the supplicant for
+      available levels and functions for emitting the messages. Note that
+      runtime filtering can also be configured in addition to the compile-time
+      filtering.

--- a/zephyr/src/supp_main.c
+++ b/zephyr/src/supp_main.c
@@ -93,7 +93,7 @@ static void start_wpa_supplicant(void)
 	struct wpa_global *global;
 
 	os_memset(&params, 0, sizeof(params));
-	params.wpa_debug_level = str_to_debug_level(CONFIG_WPA_SUPP_DEBUG_LEVEL);
+	params.wpa_debug_level = CONFIG_WPA_SUPP_DEBUG_LEVEL;
 
 	wpa_printf(MSG_INFO, "%s: %d Starting wpa_supplicant thread with debug level: %d\n",
 		  __func__, __LINE__, params.wpa_debug_level);

--- a/zephyr/src/utils/wpa_debug.c
+++ b/zephyr/src/utils/wpa_debug.c
@@ -1,0 +1,414 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * wpa_supplicant/hostapd / Debug prints
+ * Copyright (c) 2002-2013, Jouni Malinen <j@w1.fi>
+ *
+ * This software may be distributed under the terms of the BSD license.
+ * See README for more details.
+ */
+
+#include <utils/includes.h>
+#include <utils/common.h>
+
+#include "wpa_debug.h"
+
+#include <zephyr/logging/log.h>
+
+#define WPA_DEBUG_MAX_LINE_LENGTH 256
+
+LOG_MODULE_REGISTER(wpa_supp, CONFIG_WPA_SUPP_LOG_LEVEL);
+
+int wpa_debug_level = MSG_INFO;
+int wpa_debug_show_keys = 0;
+int wpa_debug_timestamp = 0;
+
+#ifndef CONFIG_NO_STDOUT_DEBUG
+
+void wpa_printf_impl(int level, const char *fmt, ...)
+{
+	va_list ap;
+	char buffer[WPA_DEBUG_MAX_LINE_LENGTH];
+
+	if (level < wpa_debug_level)
+		return;
+
+	va_start(ap, fmt);
+	vsnprintf(buffer, sizeof(buffer), fmt, ap);
+	va_end(ap);
+
+	switch (level) {
+	case MSG_ERROR:
+		LOG_ERR("%s", buffer);
+		break;
+	case MSG_WARNING:
+		LOG_WRN("%s", buffer);
+		break;
+	case MSG_INFO:
+		LOG_INF("%s", buffer);
+		break;
+	case MSG_DEBUG:
+	case MSG_MSGDUMP:
+	case MSG_EXCESSIVE:
+		LOG_DBG("%s", buffer);
+		break;
+	default:
+		break;
+	}
+
+	forced_memzero(buffer, sizeof(buffer));
+}
+
+static void _wpa_hexdump(int level, const char *title, const u8 *buf, size_t len, int show)
+{
+	size_t i;
+	const char *content;
+	char *content_buf = NULL;
+
+	if (level < wpa_debug_level)
+		return;
+
+	if (buf == NULL) {
+		content = " [NULL]";
+	} else if (show) {
+		content = content_buf = os_malloc(3 * len + 1);
+
+		if (content == NULL) {
+			wpa_printf(MSG_ERROR, "wpa_hexdump: Failed to allocate message buffer");
+			return;
+		}
+
+		for (i = 0; i < len; i++) {
+			os_snprintf(&content_buf[i * 3], 4, " %02x", buf[i]);
+		}
+	} else {
+		content = " [REMOVED]";
+	}
+
+	wpa_printf(level, "%s - hexdump(len=%lu):%s", title, (unsigned long)len, content);
+	bin_clear_free(content_buf, 3 * len + 1);
+}
+
+void wpa_hexdump_impl(int level, const char *title, const void *buf, size_t len)
+{
+	_wpa_hexdump(level, title, buf, len, 1);
+}
+
+void wpa_hexdump_key_impl(int level, const char *title, const void *buf, size_t len)
+{
+	_wpa_hexdump(level, title, buf, len, wpa_debug_show_keys);
+}
+
+static void _wpa_hexdump_ascii(int level, const char *title, const void *buf, size_t len, int show)
+{
+	const char *content;
+
+	if (level < wpa_debug_level) {
+		return;
+	}
+
+	if (buf == NULL) {
+		content = " [NULL]";
+	} else if (show) {
+		content = "";
+	} else {
+		content = " [REMOVED]";
+	}
+
+	wpa_printf(level, "%s - hexdump_ascii(len=%lu):%s", title, (unsigned long)len, content);
+
+	if (buf == NULL || !show) {
+		return;
+	}
+
+	switch (level) {
+	case MSG_ERROR:
+		LOG_HEXDUMP_ERR(buf, len, "");
+		break;
+	case MSG_WARNING:
+		LOG_HEXDUMP_WRN(buf, len, "");
+		break;
+	case MSG_INFO:
+		LOG_HEXDUMP_INF(buf, len, "");
+		break;
+	case MSG_DEBUG:
+	case MSG_MSGDUMP:
+	case MSG_EXCESSIVE:
+		LOG_HEXDUMP_DBG(buf, len, "");
+		break;
+	default:
+		break;
+	}
+}
+
+void wpa_hexdump_ascii_impl(int level, const char *title, const void *buf, size_t len)
+{
+	_wpa_hexdump_ascii(level, title, buf, len, 1);
+}
+
+void wpa_hexdump_ascii_key_impl(int level, const char *title, const void *buf, size_t len)
+{
+	_wpa_hexdump_ascii(level, title, buf, len, wpa_debug_show_keys);
+}
+
+#endif /* CONFIG_NO_STDOUT_DEBUG */
+
+#ifndef CONFIG_NO_WPA_MSG
+
+static wpa_msg_cb_func wpa_msg_cb = NULL;
+
+void wpa_msg_register_cb(wpa_msg_cb_func func)
+{
+	wpa_msg_cb = func;
+}
+
+static wpa_msg_get_ifname_func wpa_msg_ifname_cb = NULL;
+
+void wpa_msg_register_ifname_cb(wpa_msg_get_ifname_func func)
+{
+	wpa_msg_ifname_cb = func;
+}
+
+void wpa_msg_impl(void *ctx, int level, const char *fmt, ...)
+{
+	va_list ap;
+	char *buf;
+	int buflen;
+	int len;
+	char prefix[130];
+
+	va_start(ap, fmt);
+	buflen = vsnprintf(NULL, 0, fmt, ap) + 1;
+	va_end(ap);
+
+	buf = os_malloc(buflen);
+	if (buf == NULL) {
+		wpa_printf(MSG_ERROR, "wpa_msg: Failed to allocate message buffer");
+		return;
+	}
+	va_start(ap, fmt);
+	prefix[0] = '\0';
+	if (wpa_msg_ifname_cb) {
+		const char *ifname = wpa_msg_ifname_cb(ctx);
+		if (ifname) {
+			int res = os_snprintf(prefix, sizeof(prefix), "%s: ", ifname);
+			if (os_snprintf_error(sizeof(prefix), res))
+				prefix[0] = '\0';
+		}
+	}
+	len = vsnprintf(buf, buflen, fmt, ap);
+	va_end(ap);
+	wpa_printf(level, "%s%s", prefix, buf);
+	if (wpa_msg_cb)
+		wpa_msg_cb(ctx, level, WPA_MSG_PER_INTERFACE, buf, len);
+	bin_clear_free(buf, buflen);
+}
+
+void wpa_msg_ctrl_impl(void *ctx, int level, const char *fmt, ...)
+{
+	va_list ap;
+	char *buf;
+	int buflen;
+	int len;
+
+	if (!wpa_msg_cb)
+		return;
+
+	va_start(ap, fmt);
+	buflen = vsnprintf(NULL, 0, fmt, ap) + 1;
+	va_end(ap);
+
+	buf = os_malloc(buflen);
+	if (buf == NULL) {
+		wpa_printf(MSG_ERROR, "wpa_msg_ctrl: Failed to allocate message buffer");
+		return;
+	}
+	va_start(ap, fmt);
+	len = vsnprintf(buf, buflen, fmt, ap);
+	va_end(ap);
+	wpa_msg_cb(ctx, level, WPA_MSG_PER_INTERFACE, buf, len);
+	bin_clear_free(buf, buflen);
+}
+
+void wpa_msg_global_impl(void *ctx, int level, const char *fmt, ...)
+{
+	va_list ap;
+	char *buf;
+	int buflen;
+	int len;
+
+	va_start(ap, fmt);
+	buflen = vsnprintf(NULL, 0, fmt, ap) + 1;
+	va_end(ap);
+
+	buf = os_malloc(buflen);
+	if (buf == NULL) {
+		wpa_printf(MSG_ERROR, "wpa_msg_global: Failed to allocate message buffer");
+		return;
+	}
+	va_start(ap, fmt);
+	len = vsnprintf(buf, buflen, fmt, ap);
+	va_end(ap);
+	wpa_printf(level, "%s", buf);
+	if (wpa_msg_cb)
+		wpa_msg_cb(ctx, level, WPA_MSG_GLOBAL, buf, len);
+	bin_clear_free(buf, buflen);
+}
+
+void wpa_msg_global_ctrl_impl(void *ctx, int level, const char *fmt, ...)
+{
+	va_list ap;
+	char *buf;
+	int buflen;
+	int len;
+
+	if (!wpa_msg_cb)
+		return;
+
+	va_start(ap, fmt);
+	buflen = vsnprintf(NULL, 0, fmt, ap) + 1;
+	va_end(ap);
+
+	buf = os_malloc(buflen);
+	if (buf == NULL) {
+		wpa_printf(MSG_ERROR, "wpa_msg_global_ctrl: Failed to allocate message buffer");
+		return;
+	}
+	va_start(ap, fmt);
+	len = vsnprintf(buf, buflen, fmt, ap);
+	va_end(ap);
+	wpa_msg_cb(ctx, level, WPA_MSG_GLOBAL, buf, len);
+	bin_clear_free(buf, buflen);
+}
+
+void wpa_msg_no_global_impl(void *ctx, int level, const char *fmt, ...)
+{
+	va_list ap;
+	char *buf;
+	int buflen;
+	int len;
+
+	va_start(ap, fmt);
+	buflen = vsnprintf(NULL, 0, fmt, ap) + 1;
+	va_end(ap);
+
+	buf = os_malloc(buflen);
+	if (buf == NULL) {
+		wpa_printf(MSG_ERROR, "wpa_msg_no_global: Failed to allocate message buffer");
+		return;
+	}
+	va_start(ap, fmt);
+	len = vsnprintf(buf, buflen, fmt, ap);
+	va_end(ap);
+	wpa_printf(level, "%s", buf);
+	if (wpa_msg_cb)
+		wpa_msg_cb(ctx, level, WPA_MSG_NO_GLOBAL, buf, len);
+	bin_clear_free(buf, buflen);
+}
+
+void wpa_msg_global_only_impl(void *ctx, int level, const char *fmt, ...)
+{
+	va_list ap;
+	char *buf;
+	int buflen;
+	int len;
+
+	va_start(ap, fmt);
+	buflen = vsnprintf(NULL, 0, fmt, ap) + 1;
+	va_end(ap);
+
+	buf = os_malloc(buflen);
+	if (buf == NULL) {
+		wpa_printf(MSG_ERROR, "%s: Failed to allocate message buffer", __func__);
+		return;
+	}
+	va_start(ap, fmt);
+	len = vsnprintf(buf, buflen, fmt, ap);
+	va_end(ap);
+	wpa_printf(level, "%s", buf);
+	if (wpa_msg_cb)
+		wpa_msg_cb(ctx, level, WPA_MSG_ONLY_GLOBAL, buf, len);
+	os_free(buf);
+}
+
+#endif /* CONFIG_NO_WPA_MSG */
+
+#ifndef CONFIG_NO_HOSTAPD_LOGGER
+
+static hostapd_logger_cb_func hostapd_logger_cb = NULL;
+
+void hostapd_logger_register_cb(hostapd_logger_cb_func func)
+{
+	hostapd_logger_cb = func;
+}
+
+void hostapd_logger(void *ctx, const u8 *addr, unsigned int module, int level, const char *fmt, ...)
+{
+	va_list ap;
+	char *buf;
+	int buflen;
+	int len;
+
+	va_start(ap, fmt);
+	buflen = vsnprintf(NULL, 0, fmt, ap) + 1;
+	va_end(ap);
+
+	buf = os_malloc(buflen);
+	if (buf == NULL) {
+		wpa_printf(MSG_ERROR, "hostapd_logger: Failed to allocate message buffer");
+		return;
+	}
+	va_start(ap, fmt);
+	len = vsnprintf(buf, buflen, fmt, ap);
+	va_end(ap);
+	if (hostapd_logger_cb)
+		hostapd_logger_cb(ctx, addr, module, level, buf, len);
+	else if (addr)
+		wpa_printf(MSG_DEBUG, "hostapd_logger: STA " MACSTR " - %s", MAC2STR(addr), buf);
+	else
+		wpa_printf(MSG_DEBUG, "hostapd_logger: %s", buf);
+	bin_clear_free(buf, buflen);
+}
+
+#endif /* CONFIG_NO_HOSTAPD_LOGGER */
+
+const char *debug_level_str(int level)
+{
+	switch (level) {
+	case MSG_EXCESSIVE:
+		return "EXCESSIVE";
+	case MSG_MSGDUMP:
+		return "MSGDUMP";
+	case MSG_DEBUG:
+		return "DEBUG";
+	case MSG_INFO:
+		return "INFO";
+	case MSG_WARNING:
+		return "WARNING";
+	case MSG_ERROR:
+		return "ERROR";
+	default:
+		return "?";
+	}
+}
+
+int str_to_debug_level(const char *s)
+{
+	if (os_strcasecmp(s, "EXCESSIVE") == 0)
+		return MSG_EXCESSIVE;
+	if (os_strcasecmp(s, "MSGDUMP") == 0)
+		return MSG_MSGDUMP;
+	if (os_strcasecmp(s, "DEBUG") == 0)
+		return MSG_DEBUG;
+	if (os_strcasecmp(s, "INFO") == 0)
+		return MSG_INFO;
+	if (os_strcasecmp(s, "WARNING") == 0)
+		return MSG_WARNING;
+	if (os_strcasecmp(s, "ERROR") == 0)
+		return MSG_ERROR;
+	return -1;
+}

--- a/zephyr/src/utils/wpa_debug.h
+++ b/zephyr/src/utils/wpa_debug.h
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * wpa_supplicant/hostapd / Debug prints
+ * Copyright (c) 2002-2013, Jouni Malinen <j@w1.fi>
+ *
+ * This software may be distributed under the terms of the BSD license.
+ * See README for more details.
+ */
+
+#ifndef WPA_DEBUG_H
+#define WPA_DEBUG_H
+
+#include <utils/wpabuf.h>
+
+#include <zephyr/sys/__assert.h>
+
+extern int wpa_debug_level;
+extern int wpa_debug_show_keys;
+extern int wpa_debug_timestamp;
+
+enum { MSG_EXCESSIVE, MSG_MSGDUMP, MSG_DEBUG, MSG_INFO, MSG_WARNING, MSG_ERROR };
+
+/**
+ * wpa_debug_level_enabled - determine if the given priority level is enabled
+ * by compile-time configuration.
+ *
+ * @level: priority level of a message
+ */
+#define wpa_debug_level_enabled(level) (CONFIG_WPA_SUPP_DEBUG_LEVEL <= (level))
+
+/**
+ * wpa_debug_cond_run - run the action if the given condition is met
+ * 
+ * @cond: condition expression
+ * @action: action to run
+ */
+#define wpa_debug_cond_run(cond, action)                                                           \
+	do {                                                                                       \
+		if (cond) {                                                                        \
+			action;                                                                    \
+		}                                                                                  \
+	} while (0)
+
+
+#ifdef CONFIG_NO_STDOUT_DEBUG
+
+#define wpa_printf(args...) do { } while (0)
+#define wpa_hexdump(l,t,b,le) do { } while (0)
+#define wpa_hexdump_buf(l,t,b) do { } while (0)
+#define wpa_hexdump_key(l,t,b,le) do { } while (0)
+#define wpa_hexdump_buf_key(l,t,b) do { } while (0)
+#define wpa_hexdump_ascii(l,t,b,le) do { } while (0)
+#define wpa_hexdump_ascii_key(l,t,b,le) do { } while (0)
+#define wpa_dbg(args...) do { } while (0)
+
+#else /* CONFIG_NO_STDOUT_DEBUG */
+
+/**
+ * wpa_printf - conditional printf
+ *
+ * @level: priority level (MSG_*) of the message
+ * @fmt: printf format string, followed by optional arguments
+ *
+ * This function is used to print conditional debugging and error messages.
+ * The output is directed to Zephyr logging subsystem.
+ */
+#define wpa_printf(level, fmt, ...)                                                                \
+	wpa_debug_cond_run(wpa_debug_level_enabled(level),                                         \
+			   wpa_printf_impl(level, fmt, ##__VA_ARGS__))
+
+void wpa_printf_impl(int level, const char *fmt, ...) PRINTF_FORMAT(2, 3);
+
+/**
+ * wpa_hexdump - conditional hex dump
+ *
+ * @level: priority level (MSG_*) of the message
+ * @title: title of the message
+ * @buf: data buffer to be dumped
+ * @len: length of the buffer
+ *
+ * This function is used to print conditional debugging and error messages.
+ * The output is directed to Zephyr logging subsystem. The contents of buf is
+ * printed out as hex dump.
+ */
+#define wpa_hexdump(level, title, buf, len)                                                        \
+	wpa_debug_cond_run(wpa_debug_level_enabled(level), wpa_hexdump_impl(level, title, buf, len))
+
+void wpa_hexdump_impl(int level, const char *title, const void *buf, size_t len);
+
+static inline void wpa_hexdump_buf(int level, const char *title, const struct wpabuf *buf)
+{
+	wpa_hexdump(level, title, buf ? wpabuf_head(buf) : NULL, buf ? wpabuf_len(buf) : 0);
+}
+
+/**
+ * wpa_hexdump_key - conditional hex dump, hide keys
+ *
+ * @level: priority level (MSG_*) of the message
+ * @title: title of the message
+ * @buf: data buffer to be dumped
+ * @len: length of the buffer
+ *
+ * This function is used to print conditional debugging and error messages.
+ * The output is directed to Zephyr logging subsystem. The contents of buf is
+ * printed out as hex dump. This works like wpa_hexdump(), but by default, does
+ * not include secret keys (passwords, etc.) in debug output.
+ */
+#define wpa_hexdump_key(level, title, buf, len)                                                    \
+	wpa_debug_cond_run(wpa_debug_level_enabled(level),                                         \
+			   wpa_hexdump_key_impl(level, title, buf, len))
+
+void wpa_hexdump_key_impl(int level, const char *title, const void *buf, size_t len);
+
+static inline void wpa_hexdump_buf_key(int level, const char *title, const struct wpabuf *buf)
+{
+	wpa_hexdump_key(level, title, buf ? wpabuf_head(buf) : NULL, buf ? wpabuf_len(buf) : 0);
+}
+
+/**
+ * wpa_hexdump_ascii - conditional hex dump
+ * 
+ * @level: priority level (MSG_*) of the message
+ * @title: title of the message
+ * @buf: data buffer to be dumped
+ * @len: length of the buffer
+ *
+ * This function is used to print conditional debugging and error messages.
+ * The output is directed to Zephyr logging subsystem. The contents of buf is
+ * printed out as hex dump with both the hex numbers and ASCII characters (for
+ * printable range) shown. 16 bytes per line will be shown.
+ */
+#define wpa_hexdump_ascii(level, title, buf, len)                                                  \
+	wpa_debug_cond_run(wpa_debug_level_enabled(level),                                         \
+			   wpa_hexdump_ascii_impl(level, title, buf, len))
+
+void wpa_hexdump_ascii_impl(int level, const char *title, const void *buf, size_t len);
+
+/**
+ * wpa_hexdump_ascii_key - conditional hex dump, hide keys
+ * @level: priority level (MSG_*) of the message
+ * @title: title of the message
+ * @buf: data buffer to be dumped
+ * @len: length of the buffer
+ *
+ * This function is used to print conditional debugging and error messages.
+ * The output is directed to Zephyr logging subsystem. The contents of buf is
+ * printed out as hex dump with both the hex numbers and ASCII characters (for
+ * printable range) shown. 16 bytes per line will be shown. This works like
+ * wpa_hexdump_ascii(), but by default, does not include secret keys
+ * (passwords, etc.) in debug output.
+ */
+#define wpa_hexdump_ascii_key(level, title, buf, len)                                              \
+	wpa_debug_cond_run(wpa_debug_level_enabled(level),                                         \
+			   wpa_hexdump_ascii_key_impl(level, title, buf, len));
+
+void wpa_hexdump_ascii_key_impl(int level, const char *title, const void *buf, size_t len);
+
+/*
+ * wpa_dbg() behaves like wpa_msg(), but it can be removed from build to reduce
+ * binary size. As such, it should be used with debugging messages that are not
+ * needed in the control interface while wpa_msg() has to be used for anything
+ * that needs to shown to control interface monitors.
+ */
+#define wpa_dbg(args...) wpa_msg(args)
+
+#endif /* CONFIG_NO_STDOUT_DEBUG */
+
+
+#ifdef CONFIG_NO_WPA_MSG
+
+#define wpa_msg(args...) do { } while (0)
+#define wpa_msg_ctrl(args...) do { } while (0)
+#define wpa_msg_global(args...) do { } while (0)
+#define wpa_msg_global_ctrl(args...) do { } while (0)
+#define wpa_msg_no_global(args...) do { } while (0)
+#define wpa_msg_global_only(args...) do { } while (0)
+#define wpa_msg_register_cb(f) do { } while (0)
+#define wpa_msg_register_ifname_cb(f) do { } while (0)
+
+#else /* CONFIG_NO_WPA_MSG */
+
+/**
+ * wpa_msg - Conditional printf for default target and ctrl_iface monitors
+ * 
+ * @ctx: Pointer to context data; this is the ctx variable registered
+ *	with struct wpa_driver_ops::init()
+ * @level: priority level (MSG_*) of the message
+ * @fmt: printf format string, followed by optional arguments
+ *
+ * This function is used to print conditional debugging and error messages.
+ * The output is directed to Zephyr logging subsystem. This function is like
+ * wpa_printf(), but it also sends the same message to all attached ctrl_iface
+ * monitors.
+ */
+#define wpa_msg(ctx, level, fmt, ...)                                                              \
+	wpa_debug_cond_run(wpa_debug_level_enabled(level),                                         \
+			   wpa_msg_impl(ctx, level, fmt, ##__VA_ARGS__))
+
+void wpa_msg_impl(void *ctx, int level, const char *fmt, ...) PRINTF_FORMAT(3, 4);
+
+/**
+ * wpa_msg_ctrl - Conditional printf for ctrl_iface monitors
+ * 
+ * @ctx: Pointer to context data; this is the ctx variable registered
+ *	with struct wpa_driver_ops::init()
+ * @level: priority level (MSG_*) of the message
+ * @fmt: printf format string, followed by optional arguments
+ *
+ * This function is used to print conditional debugging and error messages.
+ * This function is like wpa_msg(), but it sends the output only to the
+ * attached ctrl_iface monitors. In other words, it can be used for frequent
+ * events that do not need to be sent to syslog.
+ */
+#define wpa_msg_ctrl(ctx, level, fmt, ...)                                                         \
+	wpa_debug_cond_run(wpa_debug_level_enabled(level),                                         \
+			   wpa_msg_ctrl_impl(ctx, level, fmt, ##__VA_ARGS__))
+
+void wpa_msg_ctrl_impl(void *ctx, int level, const char *fmt, ...) PRINTF_FORMAT(3, 4);
+
+/**
+ * wpa_msg_global - Global printf for ctrl_iface monitors
+ *
+ * @ctx: Pointer to context data; this is the ctx variable registered
+ *	with struct wpa_driver_ops::init()
+ * @level: priority level (MSG_*) of the message
+ * @fmt: printf format string, followed by optional arguments
+ *
+ * This function is used to print conditional debugging and error messages.
+ * This function is like wpa_msg(), but it sends the output as a global event,
+ * i.e., without being specific to an interface. For backwards compatibility,
+ * an old style event is also delivered on one of the interfaces (the one
+ * specified by the context data).
+ */
+#define wpa_msg_global(ctx, level, fmt, ...)                                                       \
+	wpa_debug_cond_run(wpa_debug_level_enabled(level),                                         \
+			   wpa_msg_global_impl(ctx, level, fmt, ##__VA_ARGS__))
+
+void wpa_msg_global_impl(void *ctx, int level, const char *fmt, ...) PRINTF_FORMAT(3, 4);
+
+/**
+ * wpa_msg_global_ctrl - Conditional global printf for ctrl_iface monitors
+ *
+ * @ctx: Pointer to context data; this is the ctx variable registered
+ *	with struct wpa_driver_ops::init()
+ * @level: priority level (MSG_*) of the message
+ * @fmt: printf format string, followed by optional arguments
+ *
+ * This function is used to print conditional debugging and error messages.
+ * This function is like wpa_msg_global(), but it sends the output only to the
+ * attached global ctrl_iface monitors. In other words, it can be used for
+ * frequent events that do not need to be sent to syslog.
+ */
+#define wpa_msg_global_ctrl(ctx, level, fmt, ...)                                                  \
+	wpa_debug_cond_run(wpa_debug_level_enabled(level),                                         \
+			   wpa_msg_global_ctrl_impl(ctx, level, fmt, ##__VA_ARGS__))
+
+void wpa_msg_global_ctrl_impl(void *ctx, int level, const char *fmt, ...) PRINTF_FORMAT(3, 4);
+
+/**
+ * wpa_msg_no_global - Conditional printf for ctrl_iface monitors
+ * 
+ * @ctx: Pointer to context data; this is the ctx variable registered
+ *	with struct wpa_driver_ops::init()
+ * @level: priority level (MSG_*) of the message
+ * @fmt: printf format string, followed by optional arguments
+ *
+ * This function is used to print conditional debugging and error messages.
+ * This function is like wpa_msg(), but it does not send the output as a global
+ * event.
+ */
+#define wpa_msg_no_global(ctx, level, fmt, ...)                                                    \
+	wpa_debug_cond_run(wpa_debug_level_enabled(level),                                         \
+			   wpa_msg_no_global_impl(ctx, level, fmt, ##__VA_ARGS__))
+
+void wpa_msg_no_global_impl(void *ctx, int level, const char *fmt, ...) PRINTF_FORMAT(3, 4);
+
+/**
+ * wpa_msg_global_only - Conditional printf for ctrl_iface monitors
+ * 
+ * @ctx: Pointer to context data; this is the ctx variable registered
+ *	with struct wpa_driver_ops::init()
+ * @level: priority level (MSG_*) of the message
+ * @fmt: printf format string, followed by optional arguments
+ *
+ * This function is used to print conditional debugging and error messages.
+ * This function is like wpa_msg_global(), but it sends the output only as a
+ * global event.
+ */
+#define wpa_msg_global_only(ctx, level, fmt, ...)                                                  \
+	wpa_debug_cond_run(wpa_debug_level_enabled(level),                                         \
+			   wpa_msg_global_only_impl(ctx, level, fmt, ##__VA_ARGS__))
+
+void wpa_msg_global_only_impl(void *ctx, int level, const char *fmt, ...) PRINTF_FORMAT(3, 4);
+
+enum wpa_msg_type {
+	WPA_MSG_PER_INTERFACE,
+	WPA_MSG_GLOBAL,
+	WPA_MSG_NO_GLOBAL,
+	WPA_MSG_ONLY_GLOBAL,
+};
+
+typedef void (*wpa_msg_cb_func)(void *ctx, int level, enum wpa_msg_type type, const char *txt,
+				size_t len);
+
+/**
+ * wpa_msg_register_cb - Register callback function for wpa_msg() messages
+ * @func: Callback function (%NULL to unregister)
+ */
+void wpa_msg_register_cb(wpa_msg_cb_func func);
+
+typedef const char * (*wpa_msg_get_ifname_func)(void *ctx);
+void wpa_msg_register_ifname_cb(wpa_msg_get_ifname_func func);
+
+#endif /* CONFIG_NO_WPA_MSG */
+
+
+#ifdef CONFIG_NO_HOSTAPD_LOGGER
+
+#define hostapd_logger(args...) do { } while (0)
+#define hostapd_logger_register_cb(f) do { } while (0)
+
+#else /* CONFIG_NO_HOSTAPD_LOGGER */
+
+#define HOSTAPD_MODULE_IEEE80211 0x00000001
+#define HOSTAPD_MODULE_IEEE8021X 0x00000002
+#define HOSTAPD_MODULE_RADIUS 0x00000004
+#define HOSTAPD_MODULE_WPA 0x00000008
+#define HOSTAPD_MODULE_DRIVER 0x00000010
+#define HOSTAPD_MODULE_MLME 0x00000040
+
+enum hostapd_logger_level {
+	HOSTAPD_LEVEL_DEBUG_VERBOSE = 0,
+	HOSTAPD_LEVEL_DEBUG = 1,
+	HOSTAPD_LEVEL_INFO = 2,
+	HOSTAPD_LEVEL_NOTICE = 3,
+	HOSTAPD_LEVEL_WARNING = 4
+};
+
+void hostapd_logger(void *ctx, const u8 *addr, unsigned int module, int level, const char *fmt, ...)
+	PRINTF_FORMAT(5, 6);
+
+typedef void (*hostapd_logger_cb_func)(void *ctx, const u8 *addr, unsigned int module, int level,
+				       const char *txt, size_t len);
+
+/**
+ * hostapd_logger_register_cb - Register callback function for hostapd_logger()
+ * @func: Callback function (NULL to unregister)
+ */
+void hostapd_logger_register_cb(hostapd_logger_cb_func func);
+
+#endif /* CONFIG_NO_HOSTAPD_LOGGER */
+
+
+/* CONFIG_DEBUG_FILE is not supported by Zephyr */
+
+static inline int wpa_debug_open_file(const char *path) { return 0; }
+static inline int wpa_debug_reopen_file(void) { return 0; }
+static inline void wpa_debug_close_file(void) {}
+static inline void wpa_debug_setup_stdout(void) {}
+
+
+/* CONFIG_DEBUG_SYSLOG is not supported by Zephyr */
+
+static inline void wpa_debug_open_syslog(void) {}
+static inline void wpa_debug_close_syslog(void) {}
+
+
+/* CONFIG_DEBUG_LINUX_TRACING is not supported by Zephyr */
+
+static inline int wpa_debug_open_linux_tracing(void) { return 0; }
+static inline void wpa_debug_close_linux_tracing(void) {}
+
+
+#ifdef EAPOL_TEST
+#define WPA_ASSERT __ASSERT
+#else
+#define WPA_ASSERT(a) do {} while (0)
+#endif
+
+
+const char * debug_level_str(int level);
+int str_to_debug_level(const char *s);
+
+#endif /* WPA_DEBUG_H */


### PR DESCRIPTION
1. Add WPA_SUPP_LOG_LEVEL_* Kconfig options to control the WPA supplicant log level the same way as other SDK components.
2. Add WPA_SUPP_DEBUG_LEVEL Kconfig option to be used for compile-time filtering of WPA supplicant debug messages. By default, it is aligned with WPA_SUPP_LOG_LEVEL.
3. Implement Zephyr variants of wpa_debug.h and wpa_debug.c files that use Zephyr logging subystem as the default output and apply compile-time filtering for the messages.

This reduces the wifi shell sample size from 626884 to 543196 bytes when `WPA_SUPP_LOG_LEVEL_ERR` is enabled.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>