### PR TITLE
Restart DHCP for every association

### DIFF
--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -709,9 +709,7 @@ static int wpa_drv_zep_set_supp_port(void *priv,
 
 #ifdef CONFIG_NET_DHCPV4
 	if (authorized) {
-		net_dhcpv4_stop(iface);
-		k_msleep(500);
-		net_dhcpv4_start(iface);
+		net_dhcpv4_restart(iface);
     }
 #endif
 


### PR DESCRIPTION
After every successful association, restart DHCP to get a fresh lease.

For the initial association this avoid delay due to DHCP exponential
retries, and also handles the case where interface has changed IP
subnet.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>