### PR TITLE
Use UNIX sockets instead of networking sockets

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -10,6 +10,7 @@ config WPA_SUPP
     depends on  NET_SOCKETS
     depends on  NET_SOCKETS_POSIX_NAMES || POSIX_API
     select NET_SOCKETS_PACKET
+    select NET_SOCKETPAIR
     select NET_L2_NRF_WIFI_MGMT
     help
       WPA WPA_SUPP


### PR DESCRIPTION
Using UDP sockets need an interface with properly configured IP address
and then either IPv4/IPv6 enabled, UNIX socket don't need any of those
and work perfectly well for IPC.

This solves two bugs:

* Matter doesn't enable IPv4, so, the events stop working, as the code
  doesn't support IPv6 sockets and also doesn't protect with IPv4
  define.

* Wi-Fi sample assigns IP address in the `prj.conf` but if an
  application doesn't do that, then socket send fails.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>