### PR TITLE
Move MbedTLS configuration files from sdk-nrf

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -27,7 +27,23 @@ config WEP
 config WPA_SUPP_CRYPTO
     bool "Crypto support for WiFi"
     select WEP
+    select MBEDTLS
+    select NRF_SECURITY
+    select MBEDTLS_LEGACY_CRYPTO_C
+    select MBEDTLS_ECP_C
+    select MBEDTLS_CTR_DRBG_C
+    select MBEDTLS_ENTROPY_C
+    select MBEDTLS_PK_WRITE_C
+    select MBEDTLS_KEY_EXCHANGE_ALL_ENABLED
     default y
+
+# Needed for internal entropy
+config MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
+    default n if WPA_SUPP_CRYPTO
+
+# To fix MAC_MD5 Kconfig warning
+config NET_TCP_ISN_RFC6528
+    default n if WPA_SUPP_CRYPTO
 
 config WPA_SUPP_CRYPTO_ENTERPRISE
     bool "Enterprise Crypto support for WiFi"


### PR DESCRIPTION
Choose necessary MbedTLS Kconfig symbols by default

MbedTLS is only used by sdk-hostap, choose the necessary Kconfig
options by default instead of relying on samples.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>