### PR TITLE
Fix Zephyr includes with latest up-merge

### DIFF
--- a/src/drivers/driver_zephyr.h
+++ b/src/drivers/driver_zephyr.h
@@ -9,8 +9,9 @@
 #ifndef DRIVER_ZEPHYR_H
 #define DRIVER_ZEPHYR_H
 
-#include <net/wifi_mgmt.h>
-#include <net/ethernet.h>
+#include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/net/ethernet.h>
+
 #include "driver.h"
 #include "wpa_supplicant_i.h"
 #include "bss.h"

--- a/src/l2_packet/l2_packet_zephyr.c
+++ b/src/l2_packet/l2_packet_zephyr.c
@@ -4,22 +4,18 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include "includes.h"
+#include <zephyr/kernel.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_pkt.h>
 
+#include "includes.h"
 #include "common.h"
 #include "eloop.h"
 #include "l2_packet.h"
 #include "common/eapol_common.h"
-
-#include <zephyr.h>
-
-#include <linker/sections.h>
-#include <toolchain.h>
-
-#include <net/net_core.h>
-#include <net/net_ip.h>
-#include <net/net_pkt.h>
-
 struct l2_packet_data {
 	char ifname[17];
 	u8 own_addr[ETH_ALEN];

--- a/src/utils/common.c
+++ b/src/utils/common.c
@@ -1304,7 +1304,7 @@ void forced_memzero(void *ptr, size_t len)
 }
 
 #ifdef CONFIG_ZEPHYR
-#include <net/net_ip.h>
+#include <zephyr/net/net_ip.h>
 extern char *inet_ntoa(struct in_addr in)
 {
 	char addr[NET_IPV4_ADDR_LEN];

--- a/src/utils/includes.h
+++ b/src/utils/includes.h
@@ -45,15 +45,15 @@
 
 #if defined(CONFIG_ZEPHYR)
 #if defined(CONFIG_POSIX_API)
-#include <posix/arpa/inet.h>
-#include <posix/sys/select.h>
-#include <posix/sys/socket.h>
-#include <posix/unistd.h>
+#include <zephyr/posix/arpa/inet.h>
+#include <zephyr/posix/sys/select.h>
+#include <zephyr/posix/sys/socket.h>
+#include <zephyr/posix/unistd.h>
 #else /* defined(CONFIG_POSIX_API) */
-#include <net/net_ip.h>
-#include <net/socket.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/socket.h>
 #endif /* defined(CONFIG_POSIX_API) */
-#include <shell/shell.h>
+#include <zephyr/shell/shell.h>
 #endif /* defined(CONFIG_ZEPHYR) */
 
 #endif /* INCLUDES_H */

--- a/src/utils/os_zephyr.c
+++ b/src/utils/os_zephyr.c
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include "includes.h"
-#include <posix/time.h>
 #include <sys/time.h>
-#include <random/rand32.h>
+
+#include <zephyr/posix/time.h>
+#include <zephyr/random/rand32.h>
+
+#include "includes.h"
 #include "os.h"
 
 void os_sleep(os_time_t sec, os_time_t usec)

--- a/wpa_supplicant/ctrl_iface.c
+++ b/wpa_supplicant/ctrl_iface.c
@@ -62,7 +62,7 @@
 #ifdef __NetBSD__
 #include <net/if_ether.h>
 #elif !defined(__CYGWIN__) && !defined(CONFIG_NATIVE_WINDOWS)
-#include <net/ethernet.h>
+#include <zephyr/net/ethernet.h>
 #endif
 
 static int wpa_supplicant_global_iface_list(struct wpa_global *global,

--- a/zephyr/src/supp_main.c
+++ b/zephyr/src/supp_main.c
@@ -12,7 +12,7 @@
  * See README for more details.
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 #include <sys/fcntl.h>
 LOG_MODULE_REGISTER(wpa_supplicant, LOG_LEVEL_DBG);
 

--- a/zephyr/src/wpa_cli.c
+++ b/zephyr/src/wpa_cli.c
@@ -12,15 +12,15 @@
 #include <stdlib.h>
 #include <ctype.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/init.h>
 
-#include <net/net_if.h>
-#include <net/wifi_mgmt.h>
-#include <net/net_event.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/net/net_event.h>
 
-#include <src/utils/common.h>
+#include <zephyr/src/utils/common.h>
 #include <wpa_supplicant/config.h>
 #include <wpa_supplicant/wpa_supplicant_i.h>
 


### PR DESCRIPTION
Zephyr has deprecated including "zephyr" directory in includes, so, all references should mandatory use "zephyr" prefix.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>