### PR TITLE
Use the PMF setting from the user

### DIFF
--- a/zephyr/src/supp_api.c
+++ b/zephyr/src/supp_api.c
@@ -238,8 +238,10 @@ int zephyr_supp_connect(const struct device *dev,
 
 		wpa_config_update_psk(ssid);
 
-		if (pmf)
-			ssid->ieee80211w = 1;
+		if (pmf) {
+			/* 1-1 Mapping */
+			ssid->ieee80211w = params->mfp;
+		}
 
 	}
 


### PR DESCRIPTION
Now that Zephyr supports taking PMF setting from the user, use that instead of hard-coding to optional.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>