### PR TITLE
Remove unncessary error message

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -29,6 +29,8 @@ config WPA_SUPP_CRYPTO
     select WEP
     select MBEDTLS
     select NRF_SECURITY
+    select MBEDTLS_CIPHER_MODE_CBC
+    select MBEDTLS_CIPHER_MODE_CTR
     select MBEDTLS_LEGACY_CRYPTO_C
     select MBEDTLS_ECP_C
     select MBEDTLS_CTR_DRBG_C

--- a/zephyr/src/supp_main.c
+++ b/zephyr/src/supp_main.c
@@ -80,9 +80,8 @@ static void iface_cb(struct net_if *iface, void *user_data)
 
 	ifindex = net_if_get_by_iface(iface);
 	link_addr = &iface->if_dev->link_addr;
+	/* 802.15.4 interface, ignore */
 	if (link_addr->len > NET_LINK_ADDR_MAX_LENGTH) {
-		wpa_printf(MSG_ERROR, "Invalid link address length, %d max %d",
-			   link_addr->len, NET_LINK_ADDR_MAX_LENGTH);
 		return;
 	}
 	os_memcpy(own_addr, link_addr->addr, link_addr->len);


### PR DESCRIPTION
If a 802.15.4 interface is present, then this is expected and not an error, so, just silently ignore.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>