### PR TITLE
SAE-H2E MbedTLS fixes

### DIFF
--- a/src/crypto/crypto_mbedtls-bignum.c
+++ b/src/crypto/crypto_mbedtls-bignum.c
@@ -125,11 +125,20 @@ int crypto_bignum_exptmod(
     const struct crypto_bignum *a, const struct crypto_bignum *b,
     const struct crypto_bignum *c, struct crypto_bignum *d)
 {
-	return mbedtls_mpi_exp_mod(
-		   (mbedtls_mpi *)d, (const mbedtls_mpi *)a,
-		   (const mbedtls_mpi *)b, (const mbedtls_mpi *)c, NULL)
-		   ? -1
-		   : 0;
+	int ret;
+
+	mbedtls_mpi res;
+
+	mbedtls_mpi_init(&res);
+	MBEDTLS_MPI_CHK(mbedtls_mpi_exp_mod(
+		   (mbedtls_mpi *)&res, (const mbedtls_mpi *)a,
+		   (const mbedtls_mpi *)b, (const mbedtls_mpi *)c, NULL));
+	MBEDTLS_MPI_CHK(mbedtls_mpi_copy((mbedtls_mpi *)d, (const mbedtls_mpi *)&res));
+
+cleanup:
+	mbedtls_mpi_free(&res);
+	return ret;
+
 }
 
 int crypto_bignum_inverse(

--- a/src/crypto/crypto_mbedtls-bignum.c
+++ b/src/crypto/crypto_mbedtls-bignum.c
@@ -167,11 +167,19 @@ int crypto_bignum_div(
     const struct crypto_bignum *a, const struct crypto_bignum *b,
     struct crypto_bignum *c)
 {
-	return mbedtls_mpi_div_mpi(
-		   (mbedtls_mpi *)c, NULL, (const mbedtls_mpi *)a,
-		   (const mbedtls_mpi *)b)
-		   ? -1
-		   : 0;
+	int ret;
+
+	mbedtls_mpi res;
+	mbedtls_mpi_init(&res);
+
+	MBEDTLS_MPI_CHK(mbedtls_mpi_div_mpi(
+		   (mbedtls_mpi *)&res, NULL, (const mbedtls_mpi *)a,
+		   (const mbedtls_mpi *)b));
+	MBEDTLS_MPI_CHK(mbedtls_mpi_copy((mbedtls_mpi *)c, (const mbedtls_mpi *)&res));
+
+cleanup:
+	mbedtls_mpi_free(&res);
+	return ret;
 }
 
 int crypto_bignum_mulmod(

--- a/src/crypto/crypto_mbedtls-ec.c
+++ b/src/crypto/crypto_mbedtls-ec.c
@@ -358,9 +358,10 @@ int crypto_ec_point_solve_y_coord(
     struct crypto_ec *e, struct crypto_ec_point *p,
     const struct crypto_bignum *x, int y_bit)
 {
-	mbedtls_mpi temp;
+	mbedtls_mpi temp, temp_no_alias;
 	mbedtls_mpi *y_sqr, *y;
 	mbedtls_mpi_init(&temp);
+	mbedtls_mpi_init(&temp_no_alias);
 	int ret = 0;
 
 	y = &((mbedtls_ecp_point *)p)->MBEDTLS_PRIVATE(Y);
@@ -381,7 +382,8 @@ int crypto_ec_point_solve_y_coord(
 	if (y_sqr) {
 
 		MBEDTLS_MPI_CHK(mbedtls_mpi_add_int(&temp, &e->group.P, 1));
-		MBEDTLS_MPI_CHK(mbedtls_mpi_div_int(&temp, NULL, &temp, 4));
+		MBEDTLS_MPI_CHK(mbedtls_mpi_div_int(&temp_no_alias, NULL, &temp, 4));
+		MBEDTLS_MPI_CHK(mbedtls_mpi_copy(&temp_no_alias, &temp));
 		MBEDTLS_MPI_CHK(
 		    mbedtls_mpi_exp_mod(y, y_sqr, &temp, &e->group.P, NULL));
 

--- a/src/crypto/crypto_mbedtls-ec.c
+++ b/src/crypto/crypto_mbedtls-ec.c
@@ -31,6 +31,8 @@ static int f_rng(void *p_rng, unsigned char *buf, size_t len)
 }
 struct crypto_ec
 {
+	/* To WAR MbedTLS optimization as A is stored 0 but assumed "-3 mod P" internally*/
+	mbedtls_mpi A;
 	mbedtls_ecp_group group;
 };
 
@@ -41,7 +43,19 @@ int crypto_rng_wrapper(void *ctx, unsigned char *buf, size_t len)
 
 const struct crypto_bignum *crypto_ec_get_a(struct crypto_ec *e)
 {
-	return (const struct crypto_bignum *)&e->group.A;
+	int ret;
+	mbedtls_mpi minus_three, one;
+
+	mbedtls_mpi_init(&e->A);
+	mbedtls_mpi_init(&minus_three);
+	mbedtls_mpi_init(&one);
+
+	MBEDTLS_MPI_CHK(mbedtls_mpi_lset(&minus_three, -3));
+	MBEDTLS_MPI_CHK(mbedtls_mpi_lset(&one, 1));
+	/* A = -3 mod P*/
+	MBEDTLS_MPI_CHK(mbedtls_mpi_exp_mod(&e->A, &minus_three, &one, &e->group.P, NULL));
+cleanup:
+	return (const struct crypto_bignum *)&e->A;
 }
 
 const struct crypto_bignum *crypto_ec_get_b(struct crypto_ec *e)


### PR DESCRIPTION
MbedTLS uses an undocumented optimization where 0/null is used for A for all NIST curves to avoid doing `-3 mod P` calculation (saves a few computations).

So, instead of returning A as is, derive it using `-3 mod P` to handle the optimization.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>