### PR TITLE
wifi : Bugfix for RRM, BTM request handling

### DIFF
--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -507,6 +507,14 @@ static int wpa_drv_mgmt_subscribe_non_ap(struct zep_drv_if_ctx *if_ctx)
 	if (wpa_drv_register_action_frame(if_ctx, (u8 *)"\x0a\x07", 2) < 0)
 		ret = -1;
 
+	/* Radio Measurement - Neighbor Report Response */
+	if (wpa_drv_register_action_frame(if_ctx, (u8 *)"\x05\x05", 2) < 0)
+		ret = -1;
+
+	/* Radio Measurement - Radio Measurement Request */
+	if (wpa_drv_register_action_frame(if_ctx, (u8 *)"\x05\x00", 2) < 0)
+		ret = -1;
+
 	return ret;
 }
 
@@ -1127,7 +1135,6 @@ static int wpa_drv_zep_set_key(void* priv,
 static int wpa_drv_zep_get_capa(void *priv,
 			       	struct wpa_driver_capa *capa)
 {
-
 	struct zep_drv_if_ctx *if_ctx = NULL;
 	const struct zep_wpa_supp_dev_ops *dev_ops = NULL;
 	int ret = -1;

--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -186,8 +186,32 @@ void wpa_drv_zep_event_proc_assoc_resp(struct zep_drv_if_ctx *if_ctx,
 
 
 void wpa_drv_zep_event_proc_deauth(struct zep_drv_if_ctx *if_ctx,
-				   union wpa_event_data *event)
+				union wpa_event_data *event, const struct ieee80211_mgmt *mgmt)
 {
+	const u8 *bssid = NULL;
+
+	bssid = mgmt->bssid;
+	
+	if ((if_ctx->capa.flags & WPA_DRIVER_FLAGS_SME) &&
+		!if_ctx->associated &&
+		os_memcmp(bssid, if_ctx->auth_bssid, ETH_ALEN) != 0 &&
+		os_memcmp(bssid, if_ctx->auth_attempt_bssid, ETH_ALEN) != 0 &&
+		os_memcmp(bssid, if_ctx->prev_bssid, ETH_ALEN) == 0)
+	{
+		/*
+		 * Avoid issues with some roaming cases where
+		 * disconnection event for the old AP may show up after
+		 * we have started connection with the new AP.
+		 * In case of locally generated event clear
+		 * ignore_next_local_deauth as well, to avoid next local
+		 * deauth event be wrongly ignored.
+		 */
+		wpa_printf(MSG_DEBUG,
+				   "nl80211: Ignore deauth/disassoc event from old AP " MACSTR " when already authenticating with " MACSTR,
+				   MAC2STR(bssid),
+				   MAC2STR(if_ctx->auth_attempt_bssid));
+		return;
+	}
 	wpa_supplicant_event_wrapper(if_ctx->supp_if_ctx,
 			EVENT_DEAUTH,
 			event);
@@ -1011,6 +1035,16 @@ static int wpa_drv_zep_authenticate(void *priv,
 		ret = -1;
 		goto out;
 	}
+	
+	if (params->bssid)
+		os_memcpy(if_ctx->auth_attempt_bssid, params->bssid, ETH_ALEN);
+
+	if (if_ctx->associated)
+		os_memcpy(if_ctx->prev_bssid, if_ctx->bssid, ETH_ALEN);
+
+	os_memset(if_ctx->auth_bssid, 0, ETH_ALEN);
+
+	if_ctx->associated = false;
 
 	ret = dev_ops->authenticate(if_ctx->dev_priv,
 			    params,
@@ -1161,6 +1195,9 @@ static int wpa_drv_zep_get_capa(void *priv,
 	}
 
 	ret = 0;
+
+	if_ctx->capa = *capa;
+
 out:
 	return ret;
 }

--- a/src/drivers/driver_zephyr.h
+++ b/src/drivers/driver_zephyr.h
@@ -124,6 +124,11 @@ struct zep_drv_if_ctx {
 	bool associated;
 
 	void *phy_info_arg;
+	struct wpa_driver_capa capa;
+
+	unsigned char prev_bssid[6];
+	unsigned char auth_bssid[6];
+	unsigned char auth_attempt_bssid[6];
 };
 
 
@@ -143,7 +148,7 @@ struct zep_wpa_supp_dev_callbk_fns {
 			   union wpa_event_data *event, unsigned int status);
 
 	void (*deauth)(struct zep_drv_if_ctx *if_ctx,
-		       union wpa_event_data *event);
+		       union wpa_event_data *event, const struct ieee80211_mgmt *mgmt);
 
 	void (*disassoc)(struct zep_drv_if_ctx *if_ctx,
 			 union wpa_event_data *event);


### PR DESCRIPTION
[SHEL-877]: DUT did not respond to AP beacon request frame
Enable RRM request/response frame handling.

[SHEL-859]: No BTM response for request from AP
Handle deauth during BSS transition

Signed-off-by: Sridhar Nuvusetty <sridhar.nuvusetty@nordicsemi.no>