### PR TITLE
Implement connect and disconnect events to Zephyr

### DIFF
--- a/wpa_supplicant/events.c
+++ b/wpa_supplicant/events.c
@@ -6,6 +6,10 @@
  * See README for more details.
  */
 
+#ifdef CONFIG_ZEPHYR
+#include <supp_events.h>
+#endif /* CONFIG_ZEPHYR */
+
 #include "includes.h"
 
 #include "common.h"
@@ -3584,6 +3588,9 @@ static void wpa_supplicant_event_disassoc(struct wpa_supplicant *wpa_s,
 			" reason=%d%s",
 			MAC2STR(bssid), reason_code,
 			locally_generated ? " locally_generated=1" : "");
+#ifdef CONFIG_ZEPHYR
+		send_wifi_mgmt_event(wpa_s->ifname, NET_EVENT_WIFI_CMD_DISCONNECT_RESULT, 0);
+#endif /* CONFIG_ZEPHYR */
 	}
 }
 

--- a/wpa_supplicant/wpa_supplicant.c
+++ b/wpa_supplicant/wpa_supplicant.c
@@ -10,6 +10,10 @@
  * functions for managing network connections.
  */
 
+#ifdef CONFIG_ZEPHYR
+#include <supp_events.h>
+#endif /* CONFIG_ZEPHYR */
+
 #include "includes.h"
 #ifdef CONFIG_MATCH_IFACE
 #include <net/if.h>
@@ -1023,6 +1027,9 @@ void wpa_supplicant_set_state(struct wpa_supplicant *wpa_s,
 			ssid && ssid->id_str ? ssid->id_str : "",
 			fils_hlp_sent ? " FILS_HLP_SENT" : "");
 #endif /* CONFIG_CTRL_IFACE || !CONFIG_NO_STDOUT_DEBUG */
+#ifdef CONFIG_ZEPHYR
+		send_wifi_mgmt_event(wpa_s->ifname, NET_EVENT_WIFI_CMD_CONNECT_RESULT, 0);
+#endif /* CONFIG_ZEPHYR */
 		wpas_clear_temp_disabled(wpa_s, ssid, 1);
 		wpa_s->consecutive_conn_failures = 0;
 		wpa_s->new_connection = 0;

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -94,6 +94,7 @@ zephyr_library_sources(
 	src/supp_main.c
 	src/utils/wpa_debug.c
 	src/supp_api.c
+	src/supp_events.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_WPA_CLI

--- a/zephyr/src/supp_events.c
+++ b/zephyr/src/supp_events.c
@@ -1,0 +1,29 @@
+#include "supp_events.h"
+
+#include "includes.h"
+#include "common.h"
+
+int send_wifi_mgmt_event(const char *ifname, enum net_event_wifi_cmd event, int status)
+{
+    const struct device *dev = device_get_binding(ifname);
+    struct net_if *iface = net_if_lookup_by_dev(dev);
+
+    if (!iface) {
+        wpa_printf(MSG_ERROR, "Could not find iface for %s", ifname);
+        return -ENODEV;
+    }
+
+    switch (event) {
+    case NET_EVENT_WIFI_CMD_CONNECT_RESULT:
+        wifi_mgmt_raise_connect_result_event(iface, status);
+        break;
+    case NET_EVENT_WIFI_CMD_DISCONNECT_RESULT:
+        wifi_mgmt_raise_disconnect_result_event(iface, status);
+        break;
+    default:
+        wpa_printf(MSG_ERROR, "Unsupported event %d", event);
+        return -EINVAL;
+    }
+
+    return 0;
+}

--- a/zephyr/src/supp_events.h
+++ b/zephyr/src/supp_events.h
@@ -1,0 +1,8 @@
+#ifndef __SUPP_EVENTS_H__
+#define __SUPP_EVENTS_H__
+
+#include <zephyr/net/wifi_mgmt.h>
+
+int send_wifi_mgmt_event(const char *ifname, enum net_event_wifi_cmd event, int status);
+
+#endif /* __SUPP_EVENTS_H__ */


### PR DESCRIPTION
These are needed for LED support for STA sample to track WPA supplicant connection state changes and blink LEDs.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>