### PR TITLE
Fix BSS age underflow

### DIFF
--- a/wpa_supplicant/bss.c
+++ b/wpa_supplicant/bss.c
@@ -936,6 +936,10 @@ void wpa_bss_flush_by_age(struct wpa_supplicant *wpa_s, int age)
 		return;
 
 	os_get_reltime(&t);
+
+	if (t.sec < age)
+		return; /* avoid underflow */
+
 	t.sec -= age;
 
 	dl_list_for_each_safe(bss, n, &wpa_s->bss, struct wpa_bss, list) {


### PR DESCRIPTION
While checking for stale BSSes, the current time is used as a basis and then based on age the stale check time is calculated, but if this is done too early in the boot and if either BOOTTIME/MONOTONIC (the one Zephyr uses by default) are used then the stale check time underflows and goes to future causing active BSS entries in the scan to be treated as stale and flushed.

Fix this by adding a check before calculating stale time and ignore this check till the system reaches the BSS expiration time (this would never happend for REALTIME clock).

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>
Signed-off-by: Sridhar Nuvusetty <sridhar.nuvusetty@nordicsemi.no>