### PR TITLE
Improve delays

### DIFF
--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -107,6 +107,7 @@ void wpa_drv_zep_event_proc_scan_done(struct zep_drv_if_ctx *if_ctx,
 			     if_ctx->supp_if_ctx);
 
 	if_ctx->scan_res2_get_in_prog = false;
+	k_sem_give(&if_ctx->drv_resp_sem);
 
 	wpa_supplicant_event_wrapper(if_ctx->supp_if_ctx,
 			EVENT_SCAN_RESULTS,
@@ -145,13 +146,10 @@ void wpa_drv_zep_event_proc_scan_res(struct zep_drv_if_ctx *if_ctx,
 
 	if_ctx->scan_res2->res = tmp;
 
-	if_ctx->scan_res2_get_in_prog = more_res;
-
-	return;
 err:
-	/* Ignore failures except the last */
 	if (!more_res) {
 		if_ctx->scan_res2_get_in_prog = false;
+		k_sem_give(&if_ctx->drv_resp_sem);
 	}
 }
 
@@ -668,6 +666,7 @@ struct hostapd_hw_modes *wpa_drv_get_hw_feature_data(void *priv,
 		return NULL;
 	}
 
+	k_sem_reset(&if_ctx->drv_resp_sem);
 	k_sem_take(&if_ctx->drv_resp_sem, K_SECONDS(GET_WIPHY_TIMEOUT));
 
 	if (!result.modes) {
@@ -889,7 +888,6 @@ struct wpa_scan_results *wpa_drv_zep_get_scan_results2(void *priv)
 {
 	struct zep_drv_if_ctx *if_ctx = NULL;
 	const struct zep_wpa_supp_dev_ops *dev_ops = NULL;
-	unsigned int i = 0;
 	int ret = -1;
 
 	if (!priv) {
@@ -924,14 +922,10 @@ struct wpa_scan_results *wpa_drv_zep_get_scan_results2(void *priv)
 
 	if_ctx->scan_res2_get_in_prog = true;
 
-	/* Wait for the device to populate the scan results */
-	while ((if_ctx->scan_res2_get_in_prog) && (i < SCAN_TIMEOUT)) {
-		k_yield();
-		os_sleep(1, 0);
-		i++;
-	}
+	k_sem_reset(&if_ctx->drv_resp_sem);
+	k_sem_take(&if_ctx->drv_resp_sem, K_SECONDS(SCAN_TIMEOUT));
 
-	if (i == SCAN_TIMEOUT) {
+	if (if_ctx->scan_res2_get_in_prog) {
 		wpa_printf(MSG_ERROR, "%s: Timed out waiting for scan results\n", __func__);
 		ret = -1;
 		goto out;

--- a/src/drivers/driver_zephyr.h
+++ b/src/drivers/driver_zephyr.h
@@ -112,6 +112,7 @@ struct zep_drv_if_ctx {
 	void *supp_if_ctx;
 	const struct device *dev_ctx;
 	void *dev_priv;
+	struct k_sem drv_resp_sem;
 
 	struct wpa_scan_results *scan_res2;
 	bool scan_res2_get_in_prog;
@@ -123,7 +124,6 @@ struct zep_drv_if_ctx {
 	bool associated;
 
 	void *phy_info_arg;
-	bool get_wiphy_in_progress;
 };
 
 


### PR DESCRIPTION
Instead of using sleep, switch to semaphore to avoid unnecessary extra loop.