### PR TITLE
Fix data access violation

### DIFF
--- a/wpa_supplicant/wpa_supplicant.c
+++ b/wpa_supplicant/wpa_supplicant.c
@@ -1027,9 +1027,6 @@ void wpa_supplicant_set_state(struct wpa_supplicant *wpa_s,
 			ssid && ssid->id_str ? ssid->id_str : "",
 			fils_hlp_sent ? " FILS_HLP_SENT" : "");
 #endif /* CONFIG_CTRL_IFACE || !CONFIG_NO_STDOUT_DEBUG */
-#ifdef CONFIG_ZEPHYR
-		send_wifi_mgmt_event(wpa_s->ifname, NET_EVENT_WIFI_CMD_CONNECT_RESULT, 0);
-#endif /* CONFIG_ZEPHYR */
 		wpas_clear_temp_disabled(wpa_s, ssid, 1);
 		wpa_s->consecutive_conn_failures = 0;
 		wpa_s->new_connection = 0;
@@ -1044,6 +1041,9 @@ void wpa_supplicant_set_state(struct wpa_supplicant *wpa_s,
 
 		sme_sched_obss_scan(wpa_s, 1);
 
+#ifdef CONFIG_ZEPHYR
+		send_wifi_mgmt_event(wpa_s->ifname, NET_EVENT_WIFI_CMD_CONNECT_RESULT, 0);
+#endif /* CONFIG_ZEPHYR */
 #if defined(CONFIG_FILS) && defined(IEEE8021X_EAPOL)
 		if (!fils_hlp_sent && ssid && ssid->eap.erp)
 			update_fils_connect_params = true;

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -69,7 +69,6 @@ zephyr_library_sources(
 	${COMMON_SRC_BASE}/utils/eloop.c
 	${COMMON_SRC_BASE}/utils/os_zephyr.c
 	${COMMON_SRC_BASE}/utils/radiotap.c
-	${COMMON_SRC_BASE}/utils/edit_simple.c
 	${WPA_SUPPLICANT_BASE}/config.c
 	${WPA_SUPPLICANT_BASE}/notify.c
 	${WPA_SUPPLICANT_BASE}/bss.c

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -75,6 +75,12 @@ config WPA_CLI
 config NET_SOCKETPAIR_BUFFER_SIZE
     default 4096 if WPA_CLI
 
+config POSIX_MAX_FDS
+    # l2_packet - 1
+    # ctrl_iface - 2 * socketpairs = 4(local and global)
+    # z_wpa_event_sock - 1 socketpair = 2
+    default 7 if !POSIX_API
+
 module = WPA_SUPP
 module-str = WPA supplicant
 source "subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
If a sample doesn't use POSIX_API then the default POSIX_MAX_FDS are 4, but Zephyr's WPA supplicant needs at least 5, so, fix this by explicitly defining it.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>