### PR TITLE
Mark Wi-Fi supported for nRF7002DK

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -12,7 +12,7 @@ config WPA_SUPP
     select NET_SOCKETS_PACKET
     select NET_SOCKETPAIR
     select NET_L2_WIFI_MGMT
-    select EXPERIMENTAL
+    select EXPERIMENTAL if !SOC_NRF5340_CPUAPP_QKAA
     help
       WPA supplicant implements 802.1X related functions.
 


### PR DESCRIPTION
EK is still experimental.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>