### PR TITLE
Get extended capabilities from driver

### DIFF
--- a/src/drivers/driver_nl80211.h
+++ b/src/drivers/driver_nl80211.h
@@ -105,10 +105,10 @@ struct wpa_driver_nl80211_data {
 	u8 *extended_capa, *extended_capa_mask;
 	unsigned int extended_capa_len;
 	struct drv_nl80211_ext_capa {
-		enum nl80211_iftype iftype;
+		enum nrf_wifi_iftype iftype;
 		u8 *ext_capa, *ext_capa_mask;
 		unsigned int ext_capa_len;
-	} iface_ext_capa[NL80211_IFTYPE_MAX];
+	} iface_ext_capa[NRF_WIFI_IFTYPE_MAX];
 	unsigned int num_iface_ext_capa;
 
 	int has_capability;

--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -1296,7 +1296,21 @@ static int wpa_drv_zep_send_action(void *priv, unsigned int freq,
 			wait_time, 0);
 }
 
+static int nl80211_get_ext_capab(void *priv, enum wpa_driver_if_type type,
+			const u8 **ext_capa, const u8 **ext_capa_mask,
+			unsigned int *ext_capa_len)
+{
+	struct wpa_driver_capa capa;
 
+	wpa_drv_zep_get_capa(priv, &capa);
+
+	/* By default, use the per-radio values */
+	*ext_capa = capa.extended_capa;
+	*ext_capa_mask = capa.extended_capa_mask;
+	*ext_capa_len = capa.extended_capa_len;
+
+	return 0;
+}
 
 const struct wpa_driver_ops wpa_driver_zep_ops = {
 	.name = "zephyr",
@@ -1319,4 +1333,5 @@ const struct wpa_driver_ops wpa_driver_zep_ops = {
 	.signal_poll = wpa_drv_zep_signal_poll,
 	.send_action = wpa_drv_zep_send_action,
 	.get_hw_feature_data = wpa_drv_get_hw_feature_data,
+	.get_ext_capab = nl80211_get_ext_capab,
 };


### PR DESCRIPTION
[SHEL-1269]: Multiple BSSID bit is not set in Association request Implement get_ext_capab op to get MBSSID support cap. info

Signed-off-by: Sridhar Nuvusetty <sridhar.nuvusetty@nordicsemi.no>