### PR TITLE
Mark nRF9160 as supported

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -12,7 +12,7 @@ config WPA_SUPP
     select NET_SOCKETS_PACKET
     select NET_SOCKETPAIR
     select NET_L2_WIFI_MGMT
-    select EXPERIMENTAL if !SOC_NRF5340_CPUAPP_QKAA
+    select EXPERIMENTAL if !SOC_SERIES_NRF53X && !SOC_SERIES_NRF91X
     help
       WPA supplicant implements 802.1X related functions.
 


### PR DESCRIPTION
This is now fully supported.