### PR TITLE
Fix POSIX build

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -8,7 +8,8 @@
 config WPA_SUPP
     bool "WPA supplicant support"
     depends on  NET_SOCKETS
-    depends on  NET_SOCKETS_POSIX_NAMES || POSIX_API
+    # Need full POSIX from libc, Zephyr's POSIX support is only partial
+    depends on !POSIX_API
     select NET_SOCKETS_PACKET
     select NET_SOCKETPAIR
     select NET_L2_WIFI_MGMT

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -10,6 +10,7 @@ config WPA_SUPP
     depends on  NET_SOCKETS
     # Need full POSIX from libc, Zephyr's POSIX support is only partial
     depends on !POSIX_API
+    select POSIX_CLOCK
     select NET_SOCKETS_PACKET
     select NET_SOCKETPAIR
     select NET_L2_WIFI_MGMT


### PR DESCRIPTION
As per [1], newlibc now defines _ANSI_SOURCE to avoid POSIX conflicts, but as hostapd needs POSIX stuff from libc, need to enable this explicitly.

[1] - https://github.com/zephyrproject-rtos/zephyr/issues/52739