### PR TITLE
[nrf noup] zephyr: remove unnecessary SYS_INIT()

### DIFF
--- a/zephyr/src/wpa_cli.c
+++ b/zephyr/src/wpa_cli.c
@@ -36,15 +36,3 @@ SHELL_CMD_REGISTER(wpa_cli,
 		   NULL,
 		   "wpa_cli commands (only for internal use)",
 		   cmd_wpa_cli);
-
-
-static int wpa_cli_init(const struct device *unused)
-{
-	ARG_UNUSED(unused);
-
-	return 0;
-}
-
-SYS_INIT(wpa_cli_init,
-	 APPLICATION,
-	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);


### PR DESCRIPTION
Commit 044ed05fe11cc2e59e1e915dc6fadcdde6bf0820
("Make WPA CLI as passthrough") made this SYS_INIT() a no-op. It's breaking the build now that SYS_INIT function signatures are 'int callback(void)'.

Remove it entirely since it does nothing.