### PR TITLE
Fix handling of IEs in authentication

### DIFF
--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -32,6 +32,21 @@ void wpa_supplicant_event_wrapper(void *ctx,
 			return;
 		}
 		os_memcpy(msg.data, data, sizeof(*data));
+		if (event == EVENT_AUTH) {
+			union wpa_event_data *data_tmp = msg.data;
+
+			if (data->auth.ies) {
+				char *ies = os_zalloc(data->auth.ies_len);
+
+				if (!ies) {
+					wpa_printf(MSG_ERROR, "%s: Failed to alloc ies\n", __func__);
+					return;
+				}
+
+				os_memcpy(ies, data->auth.ies, data->auth.ies_len);
+				data_tmp->auth.ies = ies;
+			}
+		}
 	}
 	z_wpas_send_event(&msg);
 }

--- a/zephyr/src/supp_main.c
+++ b/zephyr/src/supp_main.c
@@ -311,6 +311,11 @@ static void z_wpas_event_sock_handler(int sock, void *eloop_ctx, void *sock_ctx)
 	}
 
 	if (msg.data) {
+		if (msg.event == EVENT_AUTH) {
+			union wpa_event_data *data = msg.data;
+
+			os_free((char *)data->auth.ies);
+		}
 		os_free(msg.data);
 	}
 }


### PR DESCRIPTION
When copying event from driver and postnig to WPA supplicant, the IE's are not copied, so, if WPA supplicant takes longer to process the event the driver frees the IEs causing invalid data to be processed by WPA supplicant. This is a common issue to all events.

For now Authentication events are being affected due to WPA3-SAE taking longer to process, so, fix only Authentication events for now as a generic fix needs more work and thought.