### PR TITLE
Add support for unsolicited scan results

### DIFF
--- a/wpa_supplicant/ctrl_iface_zephyr.c
+++ b/wpa_supplicant/ctrl_iface_zephyr.c
@@ -18,8 +18,13 @@ static void wpa_supplicant_ctrl_iface_receive(int sock, void *eloop_ctx,
 	size_t reply_len = 0;
 
 	buf = os_zalloc(CTRL_IFACE_MAX_LEN + 1);
-	if (!buf)
+	if (!buf) {
+		wpa_printf(MSG_ERROR, "%s: malloc for %d failed %s",
+			   __func__, CTRL_IFACE_MAX_LEN + 1,
+			   strerror(errno));
 		return;
+	}
+
 	res = recv(sock, buf, CTRL_IFACE_MAX_LEN, 0);
 	if (res < 0) {
 		wpa_printf(MSG_ERROR, "recvfrom(ctrl_iface): %s",

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -96,7 +96,7 @@ config NET_MGMT_EVENT_STACK_SIZE
     default 4096
 
 config NET_SOCKETS_POLL_MAX
-    default 4
+    default 16
 
 module = WPA_SUPP
 module-str = WPA supplicant


### PR DESCRIPTION
For connected scan (from WPA supplicant) UMAC sends scan results on the fly i.e., it doesn't store and wait for WPA supplicant to issue get scan results.

Add support to accept and store these unsolicited scan results, they will still be returned to supplicant only when it asks.