### PR TITLE
Disable supplicant for nrf7000 device

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -10,6 +10,7 @@ config WPA_SUPP
     depends on  NET_SOCKETS
     # Need full POSIX from libc, Zephyr's POSIX support is only partial
     depends on !POSIX_API
+    depends on !SHIELD_NRF7002EK_NRF7000
     select POSIX_CLOCK
     select NET_SOCKETS_PACKET
     select NET_SOCKETPAIR


### PR DESCRIPTION
NRF7000 is a scan-only model. Hence turn off supplicant support for NRF7000 device.