### PR TITLE
Fix MbedTLS HEAP

### DIFF
--- a/zephyr/src/supp_main.c
+++ b/zephyr/src/supp_main.c
@@ -16,6 +16,10 @@
 #include <sys/fcntl.h>
 LOG_MODULE_REGISTER(wpa_supplicant, LOG_LEVEL_DBG);
 
+#if defined(CONFIG_WPA_SUPP_CRYPTO) && !defined(CONFIG_MBEDTLS_ENABLE_HEAP)
+#include <mbedtls/platform.h>
+#endif /* CONFIG_WPA_SUPP_CRYPTO */
+
 #include "includes.h"
 #include "common.h"
 #include "eloop.h"
@@ -376,6 +380,12 @@ static void z_wpas_start(void)
 {
 	struct wpa_params params;
 	int exitcode = -1;
+
+#if defined(CONFIG_WPA_SUPP_CRYPTO) && !defined(CONFIG_MBEDTLS_ENABLE_HEAP)
+	/* Needed for crypto operation as default is no-op and fails */
+	mbedtls_platform_set_calloc_free(calloc, free);
+#endif /* CONFIG_WPA_CRYPTO */
+
 	k_work_queue_init(&z_wpas_iface_wq);
 
 	k_work_queue_start(&z_wpas_iface_wq,


### PR DESCRIPTION
Commit f13d1c9b95effd9e0b802bf8566348219ea0e725 ("nrf_security: Remove usage of HEAP in platform.c") broke Wi-Fi security as MbedTLS calloc/free are now undefined and any allocations by MbedTLS will fail resulting in crypto failures.

Fix this by setting alternatives to stdlib variants.