### PR TITLE
crypto: Remove remnants of mbedtls entropy usage

### DIFF
--- a/src/crypto/tls_mbedtls.c
+++ b/src/crypto/tls_mbedtls.c
@@ -17,7 +17,6 @@
 #include <mbedtls/ssl.h>
 #include <mbedtls/x509_crt.h>
 #include <mbedtls/ctr_drbg.h>
-#include <mbedtls/entropy.h>
 #include <mbedtls/debug.h>
 #include <mbedtls/mbedtls_config.h>
 #include <assert.h>
@@ -55,8 +54,6 @@ mbedtls_ssl_export_keys_t tls_connection_export_keys_cb;
 typedef struct tls_context
 {
 	mbedtls_ssl_context ssl; /*!< TLS/SSL context */
-	mbedtls_entropy_context
-	    entropy; /*!< mbedTLS entropy context structure */
 	mbedtls_ctr_drbg_context
 	    ctr_drbg;		 /*!< mbedTLS ctr drbg context structure */
 	mbedtls_ssl_config conf; /*!< TLS/SSL config to be shared structures */
@@ -91,7 +88,6 @@ static void tls_mbedtls_cleanup(tls_context_t *tls)
 	mbedtls_x509_crt_free(&tls->cacert);
 	mbedtls_x509_crt_free(&tls->clientcert);
 	mbedtls_pk_free(&tls->clientkey);
-	mbedtls_entropy_free(&tls->entropy);
 	mbedtls_ssl_config_free(&tls->conf);
 	mbedtls_ctr_drbg_free(&tls->ctr_drbg);
 	mbedtls_ssl_free(&tls->ssl);

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -73,14 +73,9 @@ config WPA_SUPP_CRYPTO
     select MBEDTLS_LEGACY_CRYPTO_C
     select MBEDTLS_ECP_C
     select MBEDTLS_CTR_DRBG_C
-    select MBEDTLS_ENTROPY_C
     select MBEDTLS_PK_WRITE_C
     select MBEDTLS_KEY_EXCHANGE_ALL_ENABLED
     default y if !BUILD_WITH_TFM
-
-# Needed for internal entropy
-config MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
-    default n if WPA_SUPP_CRYPTO
 
 # To fix MAC_MD5 Kconfig warning
 config NET_TCP_ISN_RFC6528


### PR DESCRIPTION
Remove remnants of mbedtls entropy usage.
Entropy is now accessed through zephyr APIs so enabling MBEDTLS_ENTROPY_C is no longer needed.
Without MBEDTLS_ENTROPY_C option there is no reason to change the default configuration value of MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG.

NCSDK-22096