### PR TITLE
Add an option to disable all debugging

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -33,7 +33,6 @@ zephyr_library_compile_definitions(
 	CONFIG_NO_CONFIG_WRITE
 	CONFIG_NO_CONFIG_BLOBS
 	CONFIG_WPA_S_ZEPHYR_L2_WIFI_MGMT
-	#CONFIG_NO_STDOUT_DEBUG
 	CONFIG_CTRL_IFACE
 	CONFIG_CTRL_IFACE_ZEPHYR
 	CONFIG_NO_RANDOM_POOL
@@ -44,6 +43,10 @@ zephyr_library_compile_definitions(
 
 zephyr_library_compile_definitions_ifndef(CONFIG_WPA_SUPP_CRYPTO
 	CONFIG_NO_PBKDF2
+)
+
+zephyr_library_compile_definitions_ifdef(CONFIG_WPA_SUPP_NO_DEBUG
+	CONFIG_NO_STDOUT_DEBUG
 )
 
 zephyr_library_include_directories(

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -147,4 +147,7 @@ config WPA_SUPP_DEBUG_LEVEL
 config LOG_BUFFER_SIZE
     default 4096 if WPA_SUPP_LOG_LEVEL_DBG
     default 2048
+
+config WPA_SUPP_NO_DEBUG
+    bool "Disable printing of debug messages, saves code size significantly"
 endif


### PR DESCRIPTION
This significantly saves flash size that is much needed for Matter apps.