### PR TITLE
Register as a Native Wi-Fi stack

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -14,6 +14,7 @@ config WPA_SUPP
     select NET_SOCKETS_PACKET
     select NET_SOCKETPAIR
     select NET_L2_WIFI_MGMT
+    select WIFI_NM
     select EXPERIMENTAL if !SOC_SERIES_NRF53X && !SOC_SERIES_NRF91X
     help
       WPA supplicant implements 802.1X related functions.

--- a/zephyr/src/supp_api.c
+++ b/zephyr/src/supp_api.c
@@ -463,7 +463,8 @@ static const struct wifi_mgmt_ops *const get_wifi_mgmt_api(const struct device *
 	return off_api ? off_api->wifi_mgmt_api : NULL;
 }
 
-int z_wpa_supplicant_scan(const struct device *dev, scan_result_cb_t cb)
+int z_wpa_supplicant_scan(const struct device *dev, struct wifi_scan_params *params,
+				scan_result_cb_t cb)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
 
@@ -472,7 +473,7 @@ int z_wpa_supplicant_scan(const struct device *dev, scan_result_cb_t cb)
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->scan(dev, cb);
+	return wifi_mgmt_api->scan(dev, params, cb);
 }
 
 #ifdef CONFIG_NET_STATISTICS_WIFI

--- a/zephyr/src/supp_api.c
+++ b/zephyr/src/supp_api.c
@@ -446,3 +446,98 @@ out:
 	k_mutex_unlock(&wpa_supplicant_mutex);
 	return ret;
 }
+
+/* Below APIs are not natively supported by WPA supplicant, so,
+ * these are just wrappers around driver offload APIs. But it is
+ * transparent to the user.
+ *
+ * In the future these might be implemented natively by the WPA
+ * supplicant.
+ */
+
+static const struct wifi_mgmt_ops *const get_wifi_mgmt_api(const struct device *dev)
+{
+	struct net_wifi_mgmt_offload *off_api =
+			(struct net_wifi_mgmt_offload *) dev->api;
+
+	return off_api ? off_api->wifi_mgmt_api : NULL;
+}
+
+int z_wpa_supplicant_scan(const struct device *dev, scan_result_cb_t cb)
+{
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
+
+	if (!wifi_mgmt_api || !wifi_mgmt_api->scan) {
+		wpa_printf(MSG_ERROR, "Scan not supported");
+		return -ENOTSUP;
+	}
+
+	return wifi_mgmt_api->scan(dev, cb);
+}
+
+#ifdef CONFIG_NET_STATISTICS_WIFI
+int z_wpa_supplicant_get_stats(const struct device *dev,
+				struct net_stats_wifi *stats)
+{
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
+
+	if (!wifi_mgmt_api || !wifi_mgmt_api->get_stats) {
+		wpa_printf(MSG_ERROR, "Get stats not supported");
+		return -ENOTSUP;
+	}
+
+	return wifi_mgmt_api->get_stats(dev, stats);
+}
+#endif /* CONFIG_NET_STATISTICS_WIFI */
+
+int z_wpa_supplicant_set_power_save(const struct device *dev,
+				struct wifi_ps_params *params)
+{
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
+
+	if (!wifi_mgmt_api || !wifi_mgmt_api->set_power_save) {
+		wpa_printf(MSG_ERROR, "Set power save not supported");
+		return -ENOTSUP;
+	}
+
+	return wifi_mgmt_api->set_power_save(dev, params);
+}
+
+int z_wpa_supplicant_set_twt(const struct device *dev,
+				struct wifi_twt_params *params)
+{
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
+
+	if (!wifi_mgmt_api || !wifi_mgmt_api->set_twt) {
+		wpa_printf(MSG_ERROR, "Set TWT not supported");
+		return -ENOTSUP;
+	}
+
+	return wifi_mgmt_api->set_twt(dev, params);
+}
+
+int z_wpa_supplicant_get_power_save_config(const struct device *dev,
+				struct wifi_ps_config *config)
+{
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
+
+	if (!wifi_mgmt_api || !wifi_mgmt_api->get_power_save_config) {
+		wpa_printf(MSG_ERROR, "Get power save config not supported");
+		return -ENOTSUP;
+	}
+
+	return wifi_mgmt_api->get_power_save_config(dev, config);
+}
+
+int z_wpa_supplicant_reg_domain(const struct device *dev,
+				struct wifi_reg_domain *reg_domain)
+{
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
+
+	if (!wifi_mgmt_api || !wifi_mgmt_api->reg_domain) {
+		wpa_printf(MSG_ERROR, "Regulatory domain not supported");
+		return -ENOTSUP;
+	}
+
+	return wifi_mgmt_api->reg_domain(dev, reg_domain);
+}

--- a/zephyr/src/supp_api.c
+++ b/zephyr/src/supp_api.c
@@ -171,6 +171,35 @@ static inline int chan_to_freq(int chan)
 	return freq;
 }
 
+static inline enum wifi_frequency_bands wpas_band_to_zephyr(enum wpa_radio_work_band band)
+{
+	switch(band) {
+		case BAND_2_4_GHZ:
+			return WIFI_FREQ_BAND_2_4_GHZ;
+		case BAND_5_GHZ:
+			return WIFI_FREQ_BAND_5_GHZ;
+		default:
+			return WIFI_FREQ_BAND_UNKNOWN;
+	}
+}
+
+static inline enum wifi_security_type wpas_key_mgmt_to_zephyr(int key_mgmt)
+{
+	switch(key_mgmt) {
+		case WPA_KEY_MGMT_NONE:
+			return WIFI_SECURITY_TYPE_NONE;
+		case WPA_KEY_MGMT_PSK:
+			return WIFI_SECURITY_TYPE_PSK;
+		case WPA_KEY_MGMT_PSK_SHA256:
+			return WIFI_SECURITY_TYPE_PSK_SHA256;
+		case WPA_KEY_MGMT_SAE:
+			return WIFI_SECURITY_TYPE_SAE;
+		default:
+			return WIFI_SECURITY_TYPE_UNKNOWN;
+	}
+}
+
+/* Public API */
 int z_wpa_supplicant_connect(const struct device *dev,
 						struct wifi_connect_req_params *params)
 {
@@ -313,36 +342,6 @@ out:
 
 	return ret;
 }
-
-
-static inline enum wifi_frequency_bands wpas_band_to_zephyr(enum wpa_radio_work_band band)
-{
-	switch(band) {
-		case BAND_2_4_GHZ:
-			return WIFI_FREQ_BAND_2_4_GHZ;
-		case BAND_5_GHZ:
-			return WIFI_FREQ_BAND_5_GHZ;
-		default:
-			return WIFI_FREQ_BAND_UNKNOWN;
-	}
-}
-
-static inline enum wifi_security_type wpas_key_mgmt_to_zephyr(int key_mgmt)
-{
-	switch(key_mgmt) {
-		case WPA_KEY_MGMT_NONE:
-			return WIFI_SECURITY_TYPE_NONE;
-		case WPA_KEY_MGMT_PSK:
-			return WIFI_SECURITY_TYPE_PSK;
-		case WPA_KEY_MGMT_PSK_SHA256:
-			return WIFI_SECURITY_TYPE_PSK_SHA256;
-		case WPA_KEY_MGMT_SAE:
-			return WIFI_SECURITY_TYPE_SAE;
-		default:
-			return WIFI_SECURITY_TYPE_UNKNOWN;
-	}
-}
-
 
 int z_wpa_supplicant_status(const struct device *dev,
 				struct wifi_iface_status *status)

--- a/zephyr/src/supp_api.c
+++ b/zephyr/src/supp_api.c
@@ -171,7 +171,6 @@ static inline int chan_to_freq(int chan)
 	return freq;
 }
 
-
 int z_wpa_supplicant_connect(const struct device *dev,
 						struct wifi_connect_req_params *params)
 {

--- a/zephyr/src/supp_api.h
+++ b/zephyr/src/supp_api.h
@@ -48,11 +48,13 @@ int z_wpa_supplicant_status(const struct device *dev,
  * @brief Request a scan
  *
  * @param dev Wi-Fi interface name to use
+ * @param params Scan parameters
  * @param cb Callback to be called for each scan result
  *
  * @return 0 for OK; -1 for ERROR
  */
-int z_wpa_supplicant_scan(const struct device *dev,scan_result_cb_t cb);
+int z_wpa_supplicant_scan(const struct device *dev, struct wifi_scan_params *params,
+				scan_result_cb_t cb);
 
 #if defined(CONFIG_NET_STATISTICS_WIFI) || defined(__DOXYGEN__)
 /**

--- a/zephyr/src/supp_api.h
+++ b/zephyr/src/supp_api.h
@@ -16,7 +16,7 @@
 /**
  * @brief Request a connection
  *
- * @param iface_name: Wi-Fi interface name to use
+ * @param dev: Wi-Fi interface name to use
  * @param params: Connection details
  *
  * @return: 0 for OK; -1 for ERROR
@@ -27,7 +27,7 @@ int z_wpa_supplicant_connect(const struct device *dev,
  * @brief Forces station to disconnect and stops any subsequent scan
  *  or connection attempts
  *
- * @param iface_name: Wi-Fi interface name to use
+ * @param dev: Wi-Fi interface name to use
  *
  * @return: 0 for OK; -1 for ERROR
  */
@@ -36,11 +36,75 @@ int z_wpa_supplicant_disconnect(const struct device *dev);
 /**
  * @brief
  *
- * @param iface_name: Wi-Fi interface name to use
- * @param wifi_iface_status: Status structure to fill
+ * @param dev: Wi-Fi interface name to use
+ * @param status: Status structure to fill
  *
  * @return: 0 for OK; -1 for ERROR
  */
 int z_wpa_supplicant_status(const struct device *dev,
 	struct wifi_iface_status *status);
+
+/**
+ * @brief Request a scan
+ *
+ * @param dev Wi-Fi interface name to use
+ * @param cb Callback to be called for each scan result
+ *
+ * @return 0 for OK; -1 for ERROR
+ */
+int z_wpa_supplicant_scan(const struct device *dev,scan_result_cb_t cb);
+
+#if defined(CONFIG_NET_STATISTICS_WIFI) || defined(__DOXYGEN__)
+/**
+ * @brief Get Wi-Fi statistics
+ *
+ * @param dev Wi-Fi interface name to use
+ * @param stats Pointer to stats structure to fill
+ *
+ * @return 0 for OK; -1 for ERROR
+ */
+int z_wpa_supplicant_get_stats(const struct device *dev,
+				struct net_stats_wifi *stats);
+#endif /* CONFIG_NET_STATISTICS_WIFI || __DOXYGEN__ */
+
+/**
+ * @brief Set Wi-Fi power save configuration
+ *
+ * @param dev Wi-Fi interface name to use
+ * @param params Power save parameters to set
+ *
+ * @return 0 for OK; -1 for ERROR
+ */
+int z_wpa_supplicant_set_power_save(const struct device *dev,
+				struct wifi_ps_params *params);
+
+/**
+ * @brief Set Wi-Fi TWT parameters
+ *
+ * @param dev Wi-Fi interface name to use
+ * @param params TWT parameters to set
+ * @return 0 for OK; -1 for ERROR
+ */
+int z_wpa_supplicant_set_twt(const struct device *dev,
+				struct wifi_twt_params *params);
+
+/**
+ * @brief Get Wi-Fi power save configuration
+ *
+ * @param dev Wi-Fi interface name to use
+ * @param config Address of power save configuration to fill
+ * @return 0 for OK; -1 for ERROR
+ */
+int z_wpa_supplicant_get_power_save_config(const struct device *dev,
+				struct wifi_ps_config *config);
+
+/**
+ * @brief Set Wi-Fi Regulatory domain
+ *
+ * @param dev Wi-Fi interface name to use
+ * @param reg_domain Regulatory domain to set
+ * @return 0 for OK; -1 for ERROR
+ */
+int z_wpa_supplicant_reg_domain(const struct device *dev,
+				struct wifi_reg_domain *reg_domain);
 #endif /* ZEPHYR_SUPP_MGMT_H */

--- a/zephyr/src/supp_main.c
+++ b/zephyr/src/supp_main.c
@@ -79,9 +79,17 @@ static K_WORK_DEFINE(z_wpas_iface_work,
 K_MUTEX_DEFINE(z_wpas_event_mutex);
 
 static const struct wifi_mgmt_ops wpa_supp_ops = {
+	.scan = z_wpa_supplicant_scan,
 	.connect = z_wpa_supplicant_connect,
 	.disconnect = z_wpa_supplicant_disconnect,
 	.iface_status = z_wpa_supplicant_status,
+#ifdef CONFIG_NET_STATISTICS_WIFI
+	.get_stats = z_wpa_supplicant_get_stats,
+#endif
+	.set_power_save = z_wpa_supplicant_set_power_save,
+	.set_twt = z_wpa_supplicant_set_twt,
+	.get_power_save_config = z_wpa_supplicant_get_power_save_config,
+	.reg_domain = z_wpa_supplicant_reg_domain,
 };
 
 DEFINE_WIFI_NM_INSTANCE(wpa_supplicant, &wpa_supp_ops);


### PR DESCRIPTION
Register WPA supplicant as a Native Wi-Fi stack. Also fix a memory leak while handling the error patch in remove interface.