### PR TITLE
Fix the NCS build due to the unused symbol.

### DIFF
--- a/wpa_supplicant/ctrl_iface.c
+++ b/wpa_supplicant/ctrl_iface.c
@@ -10686,7 +10686,7 @@ fail:
 }
 #endif /* CONFIG_FILS */
 
-
+#ifndef CONFIG_NO_STDOUT_DEBUG
 static int wpas_ctrl_cmd_debug_level(const char *cmd)
 {
 	if (os_strcmp(cmd, "PING") == 0 ||
@@ -10698,7 +10698,7 @@ static int wpas_ctrl_cmd_debug_level(const char *cmd)
 		return MSG_EXCESSIVE;
 	return MSG_DEBUG;
 }
-
+#endif
 
 static int wpas_ctrl_iface_configure_mscs(struct wpa_supplicant *wpa_s,
 					  const char *cmd)
@@ -11472,8 +11472,7 @@ char * wpa_supplicant_ctrl_iface_process(struct wpa_supplicant *wpa_s,
 		wpa_hexdump_ascii_key(MSG_DEBUG, "RX ctrl_iface",
 				      (const u8 *) buf, os_strlen(buf));
 	} else {
-		int level = wpas_ctrl_cmd_debug_level(buf);
-		wpa_dbg(wpa_s, level, "Control interface command '%s'", buf);
+		wpa_dbg(wpa_s, wpas_ctrl_cmd_debug_level(buf), "Control interface command '%s'", buf);
 	}
 
 	reply = os_malloc(reply_size);


### PR DESCRIPTION
This is happening when disabling debug logs
with CONFIG_WPA_SUPP_NO_DEBUG. It's both 'level'
and 'wpas_ctrl_cmd_debug_level'.