### PR TITLE
Do not directly include mbedtls config

### DIFF
--- a/src/crypto/tls_mbedtls.c
+++ b/src/crypto/tls_mbedtls.c
@@ -18,7 +18,7 @@
 #include <mbedtls/x509_crt.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/debug.h>
-#include <mbedtls/mbedtls_config.h>
+#include <mbedtls/build_info.h>
 #include <assert.h>
 
 #include <zephyr/random/rand32.h>


### PR DESCRIPTION
Includes mbedtls/build_info.h instead.
Enables developer to use a generated or
custom config.
The following is stated in build_info.h:

>  Include this file if you need to depend on the
>  configuration options defined in mbedtls_config.h or MBEDTLS_CONFIG_FILE

If you directly use the mbedtls_config.h the config can't be overshadowed by the KConfig