### PR TITLE
[nrf noup]: wpa_supplicant: Update include paths

### DIFF
--- a/wpa_supplicant/ctrl_iface_zephyr.h
+++ b/wpa_supplicant/ctrl_iface_zephyr.h
@@ -6,9 +6,9 @@
  * See README for more details.
  */
 /* Per-interface ctrl_iface */
-#include "includes.h"
+#include "utils/includes.h"
 
-#include "common.h"
+#include "utils/common.h"
 #include "eloop.h"
 #include "config.h"
 #include "eapol_supp/eapol_supp_sm.h"


### PR DESCRIPTION
Resolved an issue while compiling the WFA-QT library, where the hostap library's include paths were incomplete for multiple header files. This resulted in "no such file or directory" errors during compilation.

To fix this, added the full paths for the necessary header files in ctrl_iface_zephyr.h. This ensures that all required headers are correctly included when building an application with the WFA-QT library.