### PR TITLE
[nrf noup] Register as a Zephyr module

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,3 @@
+build:
+  cmake-ext: True
+  kconfig-ext: True


### PR DESCRIPTION
This is needed to pickup the module in the manifest repo.