### PR TITLE
[nrf noup] codeowners: Synchronize with sdk-nrf

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # precedence.
 
 # Root folder
-*      @krish2718 @rado17 @rlubos @sachinthegreen
+*      @krish2718 @jukkar @rado17 @sachinthegreen @rlubos


### PR DESCRIPTION
As its a single module, the code owners should also be the same. Add Jukka and reorder the names.