### PR TITLE
[nrf fromlist] Add an option to remove advanced features

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -70,7 +70,7 @@ jobs:
         # debug
         ls -la
         git log  --pretty=oneline | head -n 10
-        ./scripts/ci/check_compliance.py --annotate -e KconfigBasic -e Kconfig \
+        ./scripts/ci/check_compliance.py --annotate -e gitlint -e KconfigBasic -e Kconfig \
         -c origin/${BASE_REF}..
 
     - name: upload-results
@@ -106,3 +106,16 @@ jobs:
         if [ "${exit}" == "1" ]; then
           exit 1;
         fi
+
+    - name: Get sdk-hostap main branch commit
+      if: contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
+      run: |
+        git fetch origin main
+        echo "MAIN_SHA=$(git rev-parse origin/main)" >> $GITHUB_ENV
+
+    - name: Check nRF sauce tags
+      if: contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
+      uses: nrfconnect/action-commit-tags@v1
+      with:
+        target: $GITHUB_WORKSPACE
+        revrange: $MAIN_SHA..${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -40,10 +40,6 @@ jobs:
         # Ensure there's no merge commits in the PR
         #[[ "$(git rev-list --merges --count origin/${BASE_REF}..)" == "0" ]] || \
         #(echo "::error ::Merge commits not allowed, rebase instead";false)
-        # Sauce tag checks before rebasing
-        git rev-list --first-parent origin/${BASE_REF}..HEAD | tr '\n' ',' | \
-        xargs gitlint -c ncs-sauce-tags.enable=true \
-        -c title-starts-with-subsystem.regex=".*" --commits
         git rebase origin/${BASE_REF}
         # debug
         git log  --pretty=oneline | head -n 10

--- a/hostapd/ctrl_iface.c
+++ b/hostapd/ctrl_iface.c
@@ -1541,12 +1541,14 @@ static int hostapd_ctrl_iface_set(struct hostapd_data *hapd, char *cmd)
 			hostapd_disassoc_deny_mac(hapd);
 		} else if (os_strcasecmp(cmd, "accept_mac_file") == 0) {
 			hostapd_disassoc_accept_mac(hapd);
+#ifdef CONFIG_WMM_AC
 		} else if (os_strncmp(cmd, "wme_ac_", 7) == 0 ||
 			   os_strncmp(cmd, "wmm_ac_", 7) == 0) {
 			hapd->parameter_set_count++;
 			if (ieee802_11_update_beacons(hapd->iface))
 				wpa_printf(MSG_DEBUG,
 					   "Failed to update beacons with WMM parameters");
+#endif /* CONFIG_WMM_AC */
 		} else if (os_strcmp(cmd, "wpa_passphrase") == 0 ||
 			   os_strcmp(cmd, "sae_password") == 0 ||
 			   os_strcmp(cmd, "sae_pwe") == 0) {

--- a/wpa_supplicant/scan.c
+++ b/wpa_supplicant/scan.c
@@ -258,9 +258,10 @@ static void wpas_trigger_scan_cb(struct wpa_radio_work *work, int deinit)
 			/* Clear the scan_res_handler */
 			wpa_s->scan_res_handler = NULL;
 		}
-
+#ifdef CONFIG_RRM
 		if (wpa_s->beacon_rep_data.token)
 			wpas_rrm_refuse_request(wpa_s);
+#endif /* CONFIG_RRM */
 
 		return;
 	}

--- a/wpa_supplicant/sme.c
+++ b/wpa_supplicant/sme.c
@@ -622,11 +622,12 @@ static void sme_send_authentication(struct wpa_supplicant *wpa_s,
 
 	sme_auth_handle_rrm(wpa_s, bss);
 
+#ifdef CONFIG_RRM
 	wpa_s->sme.assoc_req_ie_len += wpas_supp_op_class_ie(
 		wpa_s, ssid, bss,
 		wpa_s->sme.assoc_req_ie + wpa_s->sme.assoc_req_ie_len,
 		sizeof(wpa_s->sme.assoc_req_ie) - wpa_s->sme.assoc_req_ie_len);
-
+#endif /* CONFIG_RRM */
 	if (params.p2p)
 		wpa_drv_get_ext_capa(wpa_s, WPA_IF_P2P_CLIENT);
 	else
@@ -1907,7 +1908,7 @@ void sme_associate(struct wpa_supplicant *wpa_s, enum wpas_mode mode,
 	}
 pfs_fail:
 #endif /* CONFIG_DPP2 */
-
+#ifdef CONFIG_RRM
 	wpa_s->mscs_setup_done = false;
 	if (wpa_bss_ext_capab(wpa_s->current_bss, WLAN_EXT_CAPAB_MSCS) &&
 	    wpa_s->robust_av.valid_config) {
@@ -1941,7 +1942,7 @@ pfs_fail:
 		wpabuf_free(mscs_ie);
 	}
 mscs_fail:
-
+#endif /* CONFIG_RRM */
 	if (ssid && ssid->multi_ap_backhaul_sta) {
 		size_t multi_ap_ie_len;
 

--- a/wpa_supplicant/wpa_cli_cmds.c
+++ b/wpa_supplicant/wpa_cli_cmds.c
@@ -2491,7 +2491,7 @@ static int wpa_cli_cmd_tdls_link_status(struct wpa_ctrl *ctrl, int argc,
 	return wpa_cli_cmd(ctrl, "TDLS_LINK_STATUS", 1, argc, argv);
 }
 
-
+#ifdef CONFIG_WMM_AC
 static int wpa_cli_cmd_wmm_ac_addts(struct wpa_ctrl *ctrl, int argc,
 				    char *argv[])
 {
@@ -2511,7 +2511,7 @@ static int wpa_cli_cmd_wmm_ac_status(struct wpa_ctrl *ctrl, int argc,
 {
 	return wpa_ctrl_command(ctrl, "WMM_AC_STATUS");
 }
-
+#endif /* CONFIG_WMM_AC */
 
 static int wpa_cli_cmd_tdls_chan_switch(struct wpa_ctrl *ctrl, int argc,
 					char *argv[])
@@ -2952,7 +2952,7 @@ struct wpa_cli_cmd {
 static const struct wpa_cli_cmd wpa_cli_commands[] = {
 	{ "status", wpa_cli_cmd_status, NULL,
 	  cli_cmd_flag_none,
-	  "[verbose] = get current WPA/EAPOL/EAP status" },		
+	  "[verbose] = get current WPA/EAPOL/EAP status" },
 	{ "set_network", wpa_cli_cmd_set_network, wpa_cli_complete_network,
 	  cli_cmd_flag_sensitive,
 	  "<network id> <variable> <value> = set network variables (shows\n"

--- a/wpa_supplicant/wpa_supplicant_i.h
+++ b/wpa_supplicant/wpa_supplicant_i.h
@@ -1507,19 +1507,11 @@ struct wpa_supplicant {
 	unsigned int multi_ap_ie:1;
 	unsigned int multi_ap_backhaul:1;
 	unsigned int multi_ap_fronthaul:1;
+#ifdef CONFIG_RRM
 	struct robust_av_data robust_av;
 	bool mscs_setup_done;
-
-#ifdef CONFIG_PASN
-	struct wpas_pasn pasn;
-	struct wpa_radio_work *pasn_auth_work;
-#endif /* CONFIG_PASN */
 	struct scs_robust_av_data scs_robust_av_req;
 	u8 scs_dialog_token;
-#ifdef CONFIG_TESTING_OPTIONS
-	unsigned int disable_scs_support:1;
-	unsigned int disable_mscs_support:1;
-#endif /* CONFIG_TESTING_OPTIONS */
 	struct dl_list active_scs_ids;
 	bool ongoing_scs_req;
 	u8 dscp_req_dialog_token;
@@ -1527,6 +1519,15 @@ struct wpa_supplicant {
 	unsigned int enable_dscp_policy_capa:1;
 	unsigned int connection_dscp:1;
 	unsigned int wait_for_dscp_req:1;
+#endif /* CONFIG_RRM */
+#ifdef CONFIG_PASN
+	struct wpas_pasn pasn;
+	struct wpa_radio_work *pasn_auth_work;
+#endif /* CONFIG_PASN */
+#ifdef CONFIG_TESTING_OPTIONS
+	unsigned int disable_scs_support:1;
+	unsigned int disable_mscs_support:1;
+#endif /* CONFIG_TESTING_OPTIONS */
 };
 
 
@@ -1655,7 +1656,7 @@ int wpas_twt_send_setup(struct wpa_supplicant *wpa_s, u8 dtok, int exponent,
 			bool flow_type, u8 flow_id, bool protection,
 			u8 twt_channel, u8 control);
 int wpas_twt_send_teardown(struct wpa_supplicant *wpa_s, u8 flags);
-
+#ifdef CONFIG_RRM
 void wpas_rrm_reset(struct wpa_supplicant *wpa_s);
 void wpas_rrm_process_neighbor_rep(struct wpa_supplicant *wpa_s,
 				   const u8 *report, size_t report_len);
@@ -1673,6 +1674,7 @@ void wpas_rrm_handle_link_measurement_request(struct wpa_supplicant *wpa_s,
 					      const u8 *frame, size_t len,
 					      int rssi);
 void wpas_rrm_refuse_request(struct wpa_supplicant *wpa_s);
+#endif /* CONFIG_RRM */
 int wpas_beacon_rep_scan_process(struct wpa_supplicant *wpa_s,
 				 struct wpa_scan_results *scan_res,
 				 struct scan_info *info);


### PR DESCRIPTION
For a memory constrained system, basic Wi-Fi is enough, so, add a configuration option to compiled out advanced Wi-Fi features.

Note: wpa_cli_cmds.c changes are [noup].

Upstream-PR: https://patchwork.ozlabs.org/project/hostap/patch/20231011151937.157323-1-Chaitanya.Tata@nordicsemi.no/