### PR TITLE
[nrf fromtree] dragonfly: Fix legendre symbol calculation failure han…

### DIFF
--- a/src/common/dragonfly.c
+++ b/src/common/dragonfly.c
@@ -67,12 +67,15 @@ int dragonfly_get_random_qr_qnr(const struct crypto_bignum *prime,
 		}
 
 		res = crypto_bignum_legendre(tmp, prime);
-		if (res == 1 && !(*qr))
+		if (res == 1 && !(*qr)) {
 			*qr = tmp;
-		else if (res == -1 && !(*qnr))
+		} else if (res == -1 && !(*qnr)) {
 			*qnr = tmp;
-		else
+		} else {
 			crypto_bignum_deinit(tmp, 0);
+			if (res == -2)
+				break;
+		}
 	}
 
 	if (*qr && *qnr)


### PR DESCRIPTION
…dling

In case of low-memory conditions, the computation for legendre symbol can fail and return -2 as per documentation, but the check for that was missed here. And this can can cause an infinite loop searching for qr and qnr.

Break the loop if calculation fails, we can leave retry to the callers or user.

Upstream PR: http://lists.infradead.org/pipermail/hostap/2023-November/041879.html