### PR TITLE
[nrf noup] zephyr: Fix argument count for wpa_cli

### DIFF
--- a/wpa_supplicant/wpa_cli_cmds.c
+++ b/wpa_supplicant/wpa_cli_cmds.c
@@ -54,7 +54,7 @@ static int wpa_cli_cmd(struct wpa_ctrl *ctrl, const char *cmd, int min_args,
 		return -1;
 	}
 	memset(buf, '\0', CMD_BUF_LEN);
-	if (write_cmd(buf, CMD_BUF_LEN, cmd, argc-1, argv) < 0){
+	if (write_cmd(buf, CMD_BUF_LEN, cmd, argc, argv) < 0){
 		ret = -1;
 		goto out;
 	}
@@ -3689,7 +3689,7 @@ int wpa_request(struct wpa_ctrl *ctrl, int argc, char *argv[])
 		wpa_printf(MSG_INFO, "Unknown command '%s'\n", argv[0]);
 		ret = 1;
 	} else {
-		ret = match->handler(ctrl, argc, &argv[1]);
+		ret = match->handler(ctrl, argc - 1, &argv[1]);
 	}
 
 	return ret;


### PR DESCRIPTION
fixup! [nrf noup] zephyr: Add support for WPA CLI zephyr

For wpa_cli command the argument count was off by 1 as we remove the command itself and pass rest of the arguments to the handler. This still works fine for most, but for "interface_add" it relies of argument count for preparing command over control interface and ends up setting a L2 bridge interface which is invalid and hence causing issues.

Fixes SHEL-2196.