### PR TITLE
[nrf noup] zephyr: Fix MBO and GAS dependency

### DIFF
--- a/wpa_supplicant/mbo.c
+++ b/wpa_supplicant/mbo.c
@@ -609,7 +609,7 @@ void wpas_mbo_update_cell_capa(struct wpa_supplicant *wpa_s, u8 mbo_cell_capa)
 	wpas_update_mbo_connect_params(wpa_s);
 }
 
-
+#ifdef CONFIG_GAS
 struct wpabuf * mbo_build_anqp_buf(struct wpa_supplicant *wpa_s,
 				   struct wpa_bss *bss, u32 mbo_subtypes)
 {
@@ -645,7 +645,7 @@ struct wpabuf * mbo_build_anqp_buf(struct wpa_supplicant *wpa_s,
 
 	return anqp_buf;
 }
-
+#endif /* CONFIG_GAS */
 
 void mbo_parse_rx_anqp_resp(struct wpa_supplicant *wpa_s,
 			    struct wpa_bss *bss, const u8 *sa,

--- a/wpa_supplicant/wpa_supplicant_i.h
+++ b/wpa_supplicant/wpa_supplicant_i.h
@@ -1702,8 +1702,10 @@ size_t wpas_mbo_ie_bss_trans_reject(struct wpa_supplicant *wpa_s, u8 *pos,
 				    size_t len,
 				    enum mbo_transition_reject_reason reason);
 void wpas_mbo_update_cell_capa(struct wpa_supplicant *wpa_s, u8 mbo_cell_capa);
+#ifdef CONFIG_GAS
 struct wpabuf * mbo_build_anqp_buf(struct wpa_supplicant *wpa_s,
 				   struct wpa_bss *bss, u32 mbo_subtypes);
+#endif /* CONFIG_GAS */
 void mbo_parse_rx_anqp_resp(struct wpa_supplicant *wpa_s,
 			    struct wpa_bss *bss, const u8 *sa,
 			    const u8 *data, size_t slen);


### PR DESCRIPTION
commit eb6119524 ("[nrf fromlist] zephyr: Fix MBO build with GAS dependency") fixes the dependency in opensource acceptable way, but enable of GAS pulls in other modules costing memory.

MBO uses GAS query only for HS2.0 which isn't enabled in Zephyr, so, instead of implicitly enabling GAS in Zephyr for MBO, we protect this code with GAS, which avoids pulling in code and saves memory.

This was working till date because Zephyr toolchain silently removed the uncalled functions.

In the future if we add support for HS2.0 then GAS will be automatically enabled and this still works.