### PR TITLE
[nrf noup] zephyr: Fix sending unsolicited disconnect result

### DIFF
--- a/wpa_supplicant/events.c
+++ b/wpa_supplicant/events.c
@@ -3599,8 +3599,13 @@ static void wpa_supplicant_event_disassoc(struct wpa_supplicant *wpa_s,
 			MAC2STR(bssid), reason_code,
 			locally_generated ? " locally_generated=1" : "");
 #ifdef CONFIG_ZEPHYR
-		int status = 0;
-		send_wifi_mgmt_event(wpa_s->ifname, NET_EVENT_WIFI_CMD_DISCONNECT_RESULT, (void *)&status, sizeof(int));
+		int status = reason_code;
+
+		if (wpa_s->wpa_state >= WPA_COMPLETED) {
+			send_wifi_mgmt_event(wpa_s->ifname, NET_EVENT_WIFI_CMD_DISCONNECT_RESULT, (void *)&status, sizeof(int));
+		} else {
+			send_wifi_mgmt_event(wpa_s->ifname, NET_EVENT_WIFI_CMD_CONNECT_RESULT, (void *)&status, sizeof(int));
+		}
 #endif /* CONFIG_ZEPHYR */
 	}
 }


### PR DESCRIPTION
fixup! [nrf noup] Monitor supplicant state and inform applications

If STA is not connected but still disassociated for some reason e.g., wrong password, sending disconnect results is not intuitive as we have never sent connected status up, so, instead just send connect result with the reason code for failure.

Fixes SHEL-2265.