### PR TITLE
[nrf noup] zephyr: Handle socket close

### DIFF
--- a/wpa_supplicant/ctrl_iface_zephyr.c
+++ b/wpa_supplicant/ctrl_iface_zephyr.c
@@ -135,6 +135,13 @@ static void wpa_supplicant_ctrl_iface_receive(int sock, void *eloop_ctx,
 		os_free(buf);
 		return;
 	}
+	if (!res) {
+		eloop_unregister_sock(sock, EVENT_TYPE_READ);
+		wpa_printf(MSG_DEBUG, "ctrl_iface: Peer unexpectedly shut down "
+			   "socket");
+		os_free(buf);
+		return;
+	}
 
 	if ((size_t) res > CTRL_IFACE_MAX_LEN) {
 		wpa_printf(MSG_ERROR, "recvform(ctrl_iface): input truncated");


### PR DESCRIPTION
fixup! [nrf noup] zephyr: Add support for WPA CLI zephyr

In some cases we are receving zero bytes from the socket continuously this causes an infinite loop and starving other threads (even SHELL thread).

So, treat 0 bytes recv as EoF as its a connected socket and unregister from eloop to avoid infinite loop of recv failures.