### PR TITLE
[nrf noup] zephyr: Fix handling of zero-byte receive

### DIFF
--- a/wpa_supplicant/ctrl_iface_zephyr.c
+++ b/wpa_supplicant/ctrl_iface_zephyr.c
@@ -148,7 +148,6 @@ static void wpa_supplicant_ctrl_iface_receive(int sock, void *eloop_ctx,
 		return;
 	}
 	if (!res) {
-		eloop_unregister_sock(sock, EVENT_TYPE_READ);
 		wpa_printf(MSG_DEBUG, "ctrl_iface: Peer unexpectedly shut down "
 			   "socket");
 		os_free(buf);


### PR DESCRIPTION
fixup! [nrf noup] zephyr: Add support for WPA CLI zephyr

Sometimes even if the peer didn't close the socket, we still see zero byte receive, and un-registering for those cases causes the system to be broken.

Handle the case by ignoring the current message but keeping the socket registered.

Fixes SHEL-2283.