### PR TITLE
[nrf noup] zephyr: Fix TX status crash

### DIFF
--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -72,6 +72,24 @@ void wpa_supplicant_event_wrapper(void *ctx,
 				os_memcpy(frame, data->rx_mgmt.frame, data->rx_mgmt.frame_len);
 				data_tmp->rx_mgmt.frame = frame;
 			}
+		} else if (event == EVENT_TX_STATUS) {
+			union wpa_event_data *data_tmp = msg.data;
+			const struct ieee80211_hdr *hdr;
+
+			if (data->tx_status.data) {
+				char *frame = os_zalloc(data->tx_status.data_len);
+
+				if (!frame) {
+					wpa_printf(MSG_ERROR, "%s: Failed to alloc frame\n",
+					  __func__);
+					return;
+				}
+
+				os_memcpy(frame, data->tx_status.data, data->tx_status.data_len);
+				data_tmp->tx_status.data = frame;
+				hdr = (const struct ieee80211_hdr *) frame;
+				data_tmp->tx_status.dst = hdr->addr1;
+			}
 		}
 	}
 	z_wpas_send_event(&msg);


### PR DESCRIPTION
fixup! [nrf noup] zephyr: Redesign the events passing to wpa_supplicant from driver

Fix a crash where the stack pointer from the driver call is passed directly over the socket for async processing and if its delayed then driver stack frame is destroyed, causing a crash.

Copy the buffer from driver stack before passing over socket.