### PR TITLE
[nrf noup] zephyr: Fix reason code for locally generated disconnection

### DIFF
--- a/wpa_supplicant/events.c
+++ b/wpa_supplicant/events.c
@@ -3599,7 +3599,7 @@ static void wpa_supplicant_event_disassoc(struct wpa_supplicant *wpa_s,
 			MAC2STR(bssid), reason_code,
 			locally_generated ? " locally_generated=1" : "");
 #ifdef CONFIG_ZEPHYR
-		send_wifi_mgmt_disc_event(wpa_s, reason_code);
+		send_wifi_mgmt_disc_event(wpa_s, locally_generated ? 0 : reason_code);
 #endif /* CONFIG_ZEPHYR */
 	}
 }


### PR DESCRIPTION
In case a use issues a disconnect for some reason, it will still send IEEE 802.11 reason code 3, which will show up as a Failure (non-zero status) in Zephyr, this should only be applicable if AP sends de-authentication with reason code as "3".

Fix locally generated case to return success (the enum should also be renamed from "unspecified" to "local", but that will be handled in another PR).

Fixes SHEL-2561.