### PR TITLE
[nrf noup] wpa_supplicant: Add connection event for wrong key

### DIFF
--- a/wpa_supplicant/events.c
+++ b/wpa_supplicant/events.c
@@ -3674,6 +3674,9 @@ static void wpa_supplicant_event_disassoc_finish(struct wpa_supplicant *wpa_s,
 		if (wpas_p2p_4way_hs_failed(wpa_s) > 0)
 			return; /* P2P group removed */
 		wpas_auth_failed(wpa_s, "WRONG_KEY");
+#ifdef CONFIG_ZEPHYR
+		send_wifi_mgmt_conn_event(wpa_s, WLAN_REASON_4WAY_HANDSHAKE_TIMEOUT);
+#endif /* CONFIG_ZEPHYR */
 #ifdef CONFIG_DPP2
 		wpas_dpp_send_conn_status_result(wpa_s,
 						 DPP_STATUS_AUTH_FAILURE);


### PR DESCRIPTION
When there is a wrong password for AP, the send_wifi_mgmt_conn_event is missing for WRONG_KEY.