### PR TITLE
[nrf fromlist] wpa_supplicant: Add an option to disable SNR capping

### DIFF
--- a/wpa_supplicant/Makefile
+++ b/wpa_supplicant/Makefile
@@ -1886,6 +1886,10 @@ ifdef CONFIG_NO_TKIP
 CFLAGS += -DCONFIG_NO_TKIP
 endif
 
+ifdef CONFIG_NW_SEL_RELIABILITY
+CFLAGS += -DCONFIG_NW_SEL_RELIABILITY
+endif
+
 dynamic_eap_methods: $(EAPDYN)
 
 _OBJS_VAR := OBJS_priv

--- a/wpa_supplicant/defconfig
+++ b/wpa_supplicant/defconfig
@@ -633,3 +633,14 @@ CONFIG_DPP2=y
 # design is still subject to change. As such, this should not yet be enabled in
 # production use.
 #CONFIG_PASN=y
+
+# When selecting a network, prefer networks with a better signal strength
+# without any cap a.k.a "Great SNR".
+#
+# If this is enabled then higher SNR is preferred without any cap over higher band
+# (higher throughput) to achieve better reliability.
+#
+# If this is disabled then for networks with capped SNR, the preference is given
+# to the network with higher band (5GHz or 6GHz) and then to the network with
+# higher SNR.
+#CONFIG_NW_SEL_RELIABILITY=y

--- a/wpa_supplicant/scan.h
+++ b/wpa_supplicant/scan.h
@@ -18,6 +18,15 @@
 #define DEFAULT_NOISE_FLOOR_5GHZ (-92)
 #define DEFAULT_NOISE_FLOOR_6GHZ (-92)
 
+#ifdef CONFIG_NW_SEL_RELIABILITY
+/*
+ * This basically disables capping the SNR when choosing the best BSS. This
+ * means that the BSS with the highest SNR will be chosen, independent of the
+ * band. This is useful for scenarios where reliability is more important than
+ * throughput.
+ */
+#define GREAT_SNR 999
+#else
 /*
  * Channels with a great SNR can operate at full rate. What is a great SNR?
  * This doc https://supportforums.cisco.com/docs/DOC-12954 says, "the general
@@ -29,6 +38,7 @@
  * somewhat conservative value here.
  */
 #define GREAT_SNR 25
+#endif /* CONFIG_NW_SEL_RELIABILITY */
 
 #define IS_2P4GHZ(n) (n >= 2412 && n <= 2484)
 #define IS_5GHZ(n) (n > 4000 && n < 5895)


### PR DESCRIPTION
When selecting a network the default behaviour of WPA supplicant is to prefer higher throughput, it does this by capping the SNR.

But in certain environments, reliability is important over throughput and choosing a lower SNR (thought it is greater than "Great SNR") might be sub-optimal.

Introduce a configuration option to choose the two options (throughput or reliability).

Upstream PR: http://lists.infradead.org/pipermail/hostap/2024-March/042483.html