### PR TITLE
Upmerge 25032024

### DIFF
--- a/src/l2_packet/l2_packet_zephyr.c
+++ b/src/l2_packet/l2_packet_zephyr.c
@@ -220,7 +220,7 @@ int l2_packet_get_ip_addr(struct l2_packet_data *l2, char *buf, size_t len)
 #ifdef CONFIG_NET_IPV4
 	char addr_buf[NET_IPV4_ADDR_LEN];
 	os_strlcpy(buf, net_addr_ntop(AF_INET,
-				&l2->iface->config.ip.ipv4->unicast[0].address.in_addr.s_addr,
+				&l2->iface->config.ip.ipv4->unicast[0].ipv4.address.in_addr.s_addr,
 				addr_buf, sizeof(addr_buf)), len);
 	return 0;
 #else

--- a/src/utils/common.c
+++ b/src/utils/common.c
@@ -1302,13 +1302,3 @@ void forced_memzero(void *ptr, size_t len)
 	if (len)
 		forced_memzero_val = ((u8 *) ptr)[0];
 }
-
-#ifdef CONFIG_ZEPHYR
-#include <zephyr/net/net_ip.h>
-extern char *inet_ntoa(struct in_addr in)
-{
-	char addr[NET_IPV4_ADDR_LEN];
-
-	return net_addr_ntop(AF_INET, (const void *)&in, addr, NET_IPV4_ADDR_LEN);
-}
-#endif

--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -557,9 +557,7 @@ void int_array_concat(int **res, const int *a);
 void int_array_sort_unique(int *a);
 void int_array_add_unique(int **res, int a);
 
-#ifdef CONFIG_ZEPHYR
-char *inet_ntoa(struct in_addr in);
-#else
+#ifndef CONFIG_ZEPHYR
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 #endif
 


### PR DESCRIPTION
unicast is now a struct net_if_addr_ipv4, not net_if_addr. See 1b0f9e865e35a6b3e1ca8aad7a67f7cfbfc2e666.