### PR TITLE
[nrf noup] zephyr: Add support for fetching inactivity timer

### DIFF
--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -2035,6 +2035,29 @@ out:
 	return ret;
 }
 
+
+int wpa_drv_zep_get_inact_sec(void *priv, const u8 *addr)
+{
+	struct zep_drv_if_ctx *if_ctx = priv;
+	const struct zep_wpa_supp_dev_ops *dev_ops;
+	int ret = -1;
+
+	dev_ops = if_ctx->dev_ctx->config;
+	if (!dev_ops->get_inact_sec) {
+		wpa_printf(MSG_ERROR, "%s: get_inact_sec op not supported\n",
+			   __func__);
+		goto out;
+	}
+
+	ret = dev_ops->get_inact_sec(if_ctx->dev_priv, addr);
+	if (ret < 0) {
+		wpa_printf(MSG_ERROR, "%s: get_inact_sec op failed: %d\n", __func__, ret);
+		goto out;
+	}
+
+out:
+	return ret;
+}
 #endif /* CONFIG_AP */
 
 const struct wpa_driver_ops wpa_driver_zep_ops = {
@@ -2071,5 +2094,6 @@ const struct wpa_driver_ops wpa_driver_zep_ops = {
 	.sta_deauth = wpa_drv_zep_sta_deauth,
 	.sta_disassoc = wpa_drv_zep_sta_disassoc,
 	.sta_remove = wpa_drv_zep_sta_remove,
+	.get_inact_sec = wpa_drv_zep_get_inact_sec,
 #endif /* CONFIG_AP */
 };

--- a/src/drivers/driver_zephyr.h
+++ b/src/drivers/driver_zephyr.h
@@ -250,6 +250,8 @@ struct zep_wpa_supp_dev_ops {
 
 	int (*register_mgmt_frame)(void *if_priv, u16 frame_type,
 			size_t match_len, const u8 *match);
+
+	int (*get_inact_sec)(void *if_priv, const u8 *addr);
 };
 
 #endif /* DRIVER_ZEPHYR_H */


### PR DESCRIPTION
fixup! [nrf noup] zephyr: Implement basic AP ops

In SAP mode, need to fetch the inactivity timer value for a STA from the UMAC.

Fixes SHEL-2681.