### PR TITLE
[nrf noup] zephyr: Fix NULL de-reference

### DIFF
--- a/wpa_supplicant/wpa_cli_zephyr.c
+++ b/wpa_supplicant/wpa_cli_zephyr.c
@@ -80,7 +80,7 @@ static int _wpa_ctrl_command(struct wpa_ctrl *ctrl, const char *cmd, int print, 
 				printf("%s", buf);
 	}
 
-	if (len > 1 && (strncmp(resp, "FAIL", 4) == 0)) {
+	if (resp && len > 1 && (strncmp(resp, "FAIL", 4) == 0)) {
 		wpa_printf(MSG_ERROR, "Command failed: %s", resp);
 		return -3;
 	}


### PR DESCRIPTION
fixup! [nrf noup] zephyr: Fix failure processing of no-response commands

Add a NULL check before accessing response and response can be NULL for most commands.

Fixes SHEL-2755.