### PR TITLE
[nrf toup] Zephyr: Fix the data type for time

### DIFF
--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -9,7 +9,7 @@
 #ifndef OS_H
 #define OS_H
 
-typedef uint64_t os_time_t;
+typedef int64_t os_time_t;
 
 /**
  * os_sleep - Sleep (sec, usec)


### PR DESCRIPTION
We use subtraction operation over time, so, it has to be signed.

Fixes "[nrf toup] Use 64bit data type to store time".

Fixes SHEL-2731.