### PR TITLE
[nrf noup] zephyr: Fix the CSRNG define

### DIFF
--- a/src/utils/os_zephyr.c
+++ b/src/utils/os_zephyr.c
@@ -144,9 +144,13 @@ void os_daemonize_terminate(const char *pid_file)
 
 int os_get_random(unsigned char *buf, size_t len)
 {
+#if defined(CONFIG_ENTROPY_HAS_DRIVER)
+	return sys_csrand_get(buf, len);
+#else
 	sys_rand_get(buf, len);
 
 	return 0;
+#endif
 }
 
 unsigned long os_random(void)


### PR DESCRIPTION
CSRNG availabiluty relies on having an entropy driver, so, protect the API and fallback to non-CSRNG in case of unavailability of such driver.