### PR TITLE
[nrf noup] zephyr: struct net_if_addr_ipv4: fix address access

### DIFF
--- a/src/l2_packet/l2_packet_zephyr.c
+++ b/src/l2_packet/l2_packet_zephyr.c
@@ -220,7 +220,7 @@ int l2_packet_get_ip_addr(struct l2_packet_data *l2, char *buf, size_t len)
 #ifdef CONFIG_NET_IPV4
 	char addr_buf[NET_IPV4_ADDR_LEN];
 	os_strlcpy(buf, net_addr_ntop(AF_INET,
-				&l2->iface->config.ip.ipv4->unicast[0].address.in_addr.s_addr,
+				&l2->iface->config.ip.ipv4->unicast[0].ipv4.address.in_addr.s_addr,
 				addr_buf, sizeof(addr_buf)), len);
 	return 0;
 #else


### PR DESCRIPTION
unicast is now a struct net_if_addr_ipv4, not net_if_addr. See 1b0f9e865e35a6b3e1ca8aad7a67f7cfbfc2e666.