### PR TITLE
[nrf noup] zephyr: Disable WNM pre-scan check

### DIFF
--- a/wpa_supplicant/wnm_sta.c
+++ b/wpa_supplicant/wnm_sta.c
@@ -1607,7 +1607,7 @@ static void ieee802_11_rx_bss_trans_mgmt_req(struct wpa_supplicant *wpa_s,
 		* timestamp nor will it expire old BSSs.
 		*/
 		wpa_supplicant_update_scan_results(wpa_s, NULL);
-		if (wnm_scan_process(wpa_s, true) > 0)
+		if (wnm_scan_process(wpa_s, false) > 0)
 			return;
 		wpa_printf(MSG_DEBUG,
 			   "WNM: No valid match in previous scan results - try a new scan");


### PR DESCRIPTION
Pre-scan check modifies the behaviour when no candidate is found, with this check enabled a fresh and full scan is forced which triggers the disassociation if the timeout is closer to scan time.

Disable this check as a workaround to establish pre-upmerge WNM behaviour in case no candidate is found (WFA QT uses single AP, so, you will never find a candidate).