### PR TITLE
[nrf noup] Revert "Revert "[noup] zephyr: mbedtls: Fix certificate verification failure""

### DIFF
--- a/src/crypto/tls_mbedtls_alt.c
+++ b/src/crypto/tls_mbedtls_alt.c
@@ -2119,25 +2119,16 @@ struct wpabuf *tls_connection_handshake(void *tls_ctx,
         mbedtls_ssl_conf_session_tickets_cb(&conn->tls_conf->conf, tls_mbedtls_ssl_ticket_write,
                                             tls_mbedtls_ssl_ticket_parse, conn);
 #endif
-    int ret = 0;
 
-    if (conn->tls_conf->domain_match != NULL) {
-        ret = mbedtls_ssl_set_hostname(&conn->ssl, conn->tls_conf->domain_match);
-        if (ret != 0) {
-            wpa_printf(MSG_ERROR, "Failed to set hostname from domain match");
-            return NULL;
-        }
-    } else if (conn->tls_conf->suffix_match != NULL) {
-        ret = mbedtls_ssl_set_hostname(&conn->ssl, conn->tls_conf->suffix_match);
-        if (ret != 0) {
-            wpa_printf(MSG_ERROR, "Failed to set hostname from suffix match");
-            return NULL;
-        }
-    } else {
-        mbedtls_ssl_set_hostname(&conn->ssl, NULL);
-    }
+#ifdef MBEDTLS_X509_CRT_PARSE_C
+    /* This is insecure, but backwards as conf doesn't have hostname and
+     * for backwards compatible with MbedTLS version 3.6.3, disable
+     * hostname check. */
+    mbedtls_ssl_set_hostname(&conn->ssl, NULL);
+#endif
 
 #if MBEDTLS_VERSION_NUMBER >= 0x03020000 /* mbedtls 3.2.0 */
+    int ret = 0;
     if (conn->ssl.MBEDTLS_PRIVATE(state) == MBEDTLS_SSL_HANDSHAKE_OVER &&
         conn->ssl.MBEDTLS_PRIVATE(tls_version) == MBEDTLS_SSL_VERSION_TLS1_3)
     {


### PR DESCRIPTION
This reverts commit 6086dea5ee7406e1eede7f2ca6dff1b00b0f04e2.

The hostname checks cause failure in QT tests. While the tool
configures domain suffix check, the certificates deployed in test
are using full domain name, causing hostname validation failures.
Need to refactor the code to consider these checks.