### PR TITLE
[nrf fromlist] rsn: Allow WPA1 TKIP EAPOL-Key under FIPS with PSA MD5

### DIFF
--- a/src/common/wpa_common.c
+++ b/src/common/wpa_common.c
@@ -217,11 +217,11 @@ int wpa_eapol_key_mic(const u8 *key, size_t key_len, int akmp, int ver,
 	}
 
 	switch (ver) {
-#ifndef CONFIG_FIPS
+#if !defined(CONFIG_FIPS) || defined(CONFIG_PSA_WANT_ALG_MD5)
 	case WPA_KEY_INFO_TYPE_HMAC_MD5_RC4:
 		wpa_printf(MSG_DEBUG, "WPA: EAPOL-Key MIC using HMAC-MD5");
 		return hmac_md5(key, key_len, buf, len, mic);
-#endif /* CONFIG_FIPS */
+#endif /* !CONFIG_FIPS || CONFIG_PSA_WANT_ALG_MD5 */
 	case WPA_KEY_INFO_TYPE_HMAC_SHA1_AES:
 		wpa_printf(MSG_DEBUG, "WPA: EAPOL-Key MIC using HMAC-SHA1");
 		if (hmac_sha1(key, key_len, buf, len, hash))

--- a/src/rsn_supp/wpa.c
+++ b/src/rsn_supp/wpa.c
@@ -3220,11 +3220,11 @@ static void wpa_supplicant_process_1_of_2_wpa(struct wpa_sm *sm,
 	gd.keyidx = (key_info & WPA_KEY_INFO_KEY_INDEX_MASK) >>
 		WPA_KEY_INFO_KEY_INDEX_SHIFT;
 	if (ver == WPA_KEY_INFO_TYPE_HMAC_MD5_RC4 && sm->ptk.kek_len == 16) {
-#if defined(CONFIG_NO_RC4) || defined(CONFIG_FIPS)
+#if defined(CONFIG_NO_RC4) || (defined(CONFIG_FIPS) && !defined(CONFIG_PSA_WANT_ALG_MD5))
 		wpa_msg(sm->ctx->msg_ctx, MSG_WARNING,
 			"WPA: RC4 not supported in the build");
 		goto failed;
-#else /* CONFIG_NO_RC4 || CONFIG_FIPS */
+#else /* CONFIG_NO_RC4 || (CONFIG_FIPS && !CONFIG_PSA_WANT_ALG_MD5) */
 		u8 ek[32];
 		if (key_data_len > sizeof(gd.gtk)) {
 			wpa_msg(sm->ctx->msg_ctx, MSG_WARNING,
@@ -3242,7 +3242,7 @@ static void wpa_supplicant_process_1_of_2_wpa(struct wpa_sm *sm,
 			goto failed;
 		}
 		forced_memzero(ek, sizeof(ek));
-#endif /* CONFIG_NO_RC4 || CONFIG_FIPS */
+#endif /* CONFIG_NO_RC4 || (CONFIG_FIPS && !CONFIG_PSA_WANT_ALG_MD5) */
 	} else if (ver == WPA_KEY_INFO_TYPE_HMAC_SHA1_AES) {
 		if (maxkeylen % 8) {
 			wpa_msg(sm->ctx->msg_ctx, MSG_WARNING,
@@ -3523,11 +3523,11 @@ static int wpa_supplicant_decrypt_key_data(struct wpa_sm *sm,
 	/* Decrypt key data here so that this operation does not need
 	 * to be implemented separately for each message type. */
 	if (ver == WPA_KEY_INFO_TYPE_HMAC_MD5_RC4 && sm->ptk.kek_len == 16) {
-#if defined(CONFIG_NO_RC4) || defined(CONFIG_FIPS)
+#if defined(CONFIG_NO_RC4) || (defined(CONFIG_FIPS) && !defined(CONFIG_PSA_WANT_ALG_MD5))
 		wpa_msg(sm->ctx->msg_ctx, MSG_WARNING,
 			"WPA: RC4 not supported in the build");
 		return -1;
-#else /* CONFIG_NO_RC4 || CONFIG_FIPS */
+#else /* CONFIG_NO_RC4 || (CONFIG_FIPS && !CONFIG_PSA_WANT_ALG_MD5) */
 		u8 ek[32];
 
 		wpa_printf(MSG_DEBUG, "WPA: Decrypt Key Data using RC4");
@@ -3540,7 +3540,7 @@ static int wpa_supplicant_decrypt_key_data(struct wpa_sm *sm,
 			return -1;
 		}
 		forced_memzero(ek, sizeof(ek));
-#endif /* CONFIG_NO_RC4 || CONFIG_FIPS */
+#endif /* CONFIG_NO_RC4 || (CONFIG_FIPS && !CONFIG_PSA_WANT_ALG_MD5) */
 	} else if (ver == WPA_KEY_INFO_TYPE_HMAC_SHA1_AES ||
 		   ver == WPA_KEY_INFO_TYPE_AES_128_CMAC ||
 		   wpa_use_aes_key_wrap(sm->key_mgmt)) {


### PR DESCRIPTION
Zephyr hostap builds with CONFIG_FIPS, which strips HMAC-MD5 and RC4 call sites even when the PSA backend provides them. WPA-PSK (WPA1) APs require EAPOL-Key descriptor version 1: HMAC-MD5 for the 4-way MIC and RC4 for group-key unwrap. That breaks association with legacy and QuickTrack WPA-PSK test APs.

When CONFIG_PSA_WANT_ALG_MD5 is set (personal STA crypto backends that explicitly enable legacy TKIP interop), allow the ver=1 MIC and RC4 key data paths. Builds without PSA MD5 keep the existing FIPS blocks.

Upstream PR #: 144


Assisted-by: Cursor:Auto

manifest-pr-skip